### PR TITLE
openapiで全APIの項目を洗い出す（cnv 133）

### DIFF
--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -5,6 +5,27 @@ info:
 servers:
   - url: /v1
 paths:
+  /sentences:
+    post:
+      tags:
+        - sentences
+      operationId: postSentence
+      summary: "メイン投稿の続きの新規投稿を作成"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PostSentence"
+      responses:
+        '201':
+          description: "新規投稿の追加に成功"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ViewSentence"
+        '400':
+          description: "新規投稿の追加に失敗"
   /sentences/{sentence_id}:
     get:
       tags:
@@ -26,46 +47,12 @@ paths:
                 $ref: "#/components/schemas/ViewSentence"
         '404':
           description: "投稿が見つからない"
-    post:
-      tags:
-        - sentences
-      operationId: postSentence
-      summary: "投稿IDの続きの新規投稿を作成"
-      parameters:
-        - name: sentence_id
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PostSentence"
-      responses:
-        '201':
-          description: "新規投稿の追加に成功"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ViewSentence"
-        '400':
-          description: "新規投稿の追加に失敗"
-  /evaluations/{sentence_id}:
+  /evaluations:
     post:
       tags:
         - evaluations
       operationId: evaluateSentence
       summary: "投稿に対する評価を追加"
-      parameters:
-        - name: sentence_id
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
       requestBody:
         required: true
         content:
@@ -81,7 +68,7 @@ paths:
                 $ref: "#/components/schemas/ViewEvaluation"
         '400':
           description: "評価の追加に失敗"
-  /novels/:
+  /novels:
     get:
       tags:
         - novels
@@ -89,7 +76,7 @@ paths:
       summary: "小説一覧を取得"
       responses:
         '200':
-          description: "小説一覧"
+          description: "直近で後続の投稿があったものを先頭にした小説一覧"
           content:
             application/json:
               schema:
@@ -115,7 +102,7 @@ paths:
                 $ref: "#/components/schemas/NovelOverview"
         '404':
           description: "小説が見つからない"
-  /users/:
+  /users: # 不要なAPI？（調査中）
     post:
       tags:
         - users
@@ -136,38 +123,27 @@ paths:
                 $ref: "#/components/schemas/RegisterUserResult"
         '400':
           description: "ユーザー登録に失敗"
-  /users/{user_id}:
+  /users/me: # 他のユーザーに表示させたくない情報を含むためmeに変更
     get:
       tags:
         - users
-      operationId: getUserById
-      summary: "IDでユーザーアカウント情報を取得"
-      parameters:
-        - name: user_id
-          in: path
-          required: true
-          schema:
-            type: integer
+      operationId: getUserByMe
+      summary: "自分自身のユーザーアカウント情報を取得"
       responses:
         '200':
-          description: "ユーザーIDで取得したユーザーアカウント情報"
+          description: "自分自身のユーザーアカウント情報"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
+                $ref: "#/components/schemas/ViewMeUser"
         '404':
           description: "ユーザーが見つからない"
-    post: # 部分更新にはpatchの方が適切かも（要検討）
+  /users/me/update: # 他のユーザーにアカウント更新させたくないためmeに変更
+    post:
       tags:
         - users
-      operationId: updateUserById
-      summary: "IDでユーザーアカウント情報を更新"
-      parameters:
-        - name: user_id
-          in: path
-          required: true
-          schema:
-            type: integer
+      operationId:  updateUserByMe
+      summary: "自分自身のユーザーアカウント情報を更新"
       requestBody:
         required: true
         content:
@@ -183,17 +159,12 @@ paths:
                 $ref: "#/components/schemas/User"
         '400':
           description: "ユーザー情報の更新に失敗"
-    delete:
+  /users/me/delete: # 他のユーザーにアカウント削除させたくないためmeに変更
+    post:
       tags:
         - users
-      operationId: deleteUserById
-      summary: "IDでユーザーアカウントを削除"
-      parameters:
-        - name: user_id
-          in: path
-          required: true
-          schema:
-            type: integer
+      operationId:  deleteUserByMe
+      summary: "自分自身のユーザーアカウントを削除（論理削除）"
       requestBody:
         required: true
         content:
@@ -205,7 +176,43 @@ paths:
           description: "ユーザーの削除に成功"
         '400':
           description: "ユーザーの削除に失敗"
-  /users/{user_id}/posted-novels:
+  /users/me/viewed_novels: # 他のユーザーに表示させたくない情報を含むためmeに変更
+    get:
+      tags:
+        - users
+      operationId: getViewedNovelsByMe
+      summary: "自分自身が閲覧している小説一覧を取得"
+      responses:
+        '200':
+          description: "自分自身が閲覧している小説一覧"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Novels"
+        '404':
+          description: "ユーザーが見つからない"
+  /users/{user_id}:
+    get:
+      tags:
+        - users
+      operationId: getUserById
+      summary: "IDで自分以外のユーザーアカウント情報を取得"
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: "ユーザーIDで取得したユーザーアカウント情報"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        '404':
+          description: "ユーザーが見つからない"
+  /users/{user_id}/posted_novels:
     get:
       tags:
         - users
@@ -226,28 +233,7 @@ paths:
                 $ref: "#/components/schemas/Novels"
         '404':
           description: "ユーザーが見つからない"
-  /users/{user_id}/viewed-novels:
-    get:
-      tags:
-        - users
-      operationId: getViewedNovelsByUserId
-      summary: "ユーザーが閲覧している小説一覧を取得"
-      parameters:
-        - name: user_id
-          in: path
-          required: true
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: "ユーザーIDで取得したユーザーが閲覧している小説一覧"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Novels"
-        '404':
-          description: "ユーザーが見つからない"
-  /auth/login:
+  /auth/login: # 不要なAPI？（調査中）
     post:
       tags:
         - auth
@@ -268,7 +254,7 @@ paths:
                 $ref: "#/components/schemas/LoginResponse"
         '401':
           description: "認証失敗"
-  /auth/logout:
+  /auth/logout: # 不要なAPI？（調査中）
     post:
       tags:
         - auth
@@ -343,14 +329,6 @@ components:
           type: integer
           format: int64
           description: "親投稿のid"
-        parent_sentence_user_id:
-          type: integer
-          format: int64
-          description: "親投稿のユーザーid"
-        sentence_user_id:
-          type: integer
-          format: int64
-          description: "新投稿のユーザーid"
         sentence:
           type: string
           description: "新投稿の本文テキスト"
@@ -361,10 +339,6 @@ components:
           type: integer
           format: int64
           description: "評価対象の投稿のID"
-        evaluator_user_id:
-          type: integer
-          format: int64
-          description: "評価を行ったユーザーのID"
         evaluation:
           type: string
           enum: [good, bad, stay]
@@ -412,15 +386,18 @@ components:
           items:
             type: string
           description: "小説のジャンル"
-        is_new:
+        is_new: # ブラウザ側で判定するなら不要？
           type: boolean
           description: "新着小説かどうか"
-        is_famous:
+        is_famous: # ブラウザ側で判定するなら不要？
           type: boolean
           description: "人気小説かどうか"
         view_count:
           type: integer
           description: "小説の閲覧数"
+        evaluation_good_count: # 追加（メダル数を表示しない代わりに）
+          type: integer
+          description: "小説のGood評価の数"
         created_at:
           type: string
           format: date-time
@@ -516,16 +493,10 @@ components:
         nick_name:
           type: string
           description: "ユーザーのニックネーム"
-        birth_year_and_month:
-          type: string
-          description: "ユーザーの生年月（YYYY/MM）"
-        is_anonymous:
-          type: boolean
-          description: "匿名設定"
         profile_icon_image:
           type: string
           description: "ユーザーアイコン画像のurl"
-        good_count:
+        evaluation_good_count:
           type: integer
           description: "Good評価の数"
         created_at:
@@ -536,6 +507,17 @@ components:
           type: string
           format: date-time
           description: "ユーザーの修正日時"
+    ViewMeUser:
+      allOf:
+        - $ref: "#/components/schemas/User"
+        - type: object
+          properties:
+            birth_year_and_month:
+              type: string
+              description: "ユーザーの生年月（YYYY/MM）"
+            is_anonymous:
+              type: boolean
+              description: "匿名設定"
     UpdateUser:
       type: object
       properties:

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -115,6 +115,27 @@ paths:
                 $ref: "#/components/schemas/NovelOverview"
         '404':
           description: "小説が見つからない"
+  /users/:
+    post:
+      tags:
+        - users
+      operationId: registerUser
+      summary: "ユーザー登録"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterUser"
+      responses:
+        '201':
+          description: "ユーザー登録に成功"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegisterUserResult"
+        '400':
+          description: "ユーザー登録に失敗"
 components:
   schemas:
     Sentence:
@@ -280,3 +301,27 @@ components:
             overview:
               type: string
               description: "小説の概要"
+    RegisterUser:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          description: "ユーザーのメールアドレス"
+        google_sub:
+          type: string
+          maxLength: 128
+          description: "Googleのサブジェクト識別子"
+    RegisterUserResult:
+      allOf:
+        - $ref: "#/components/schemas/RegisterUser"
+        - type: object
+          properties:
+            user_id:
+              type: integer
+              format: int64
+              description: "ユーザーの一意のid"
+            created_at:
+              type: string
+              format: date-time
+              description: "ユーザーの作成日時"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -108,7 +108,7 @@ paths:
             type: integer
       responses:
         '200':
-          description: "小説IDで取得した小説"
+          description: "小説IDで取得した小説の概要"
           content:
             application/json:
               schema:
@@ -136,12 +136,33 @@ paths:
                 $ref: "#/components/schemas/RegisterUserResult"
         '400':
           description: "ユーザー登録に失敗"
+  /users/{user_id}:
+    get:
+      tags:
+        - users
+      operationId: getUserById
+      summary: "IDでユーザーアカウント情報を取得"
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: "ユーザーIDで取得したユーザーアカウント情報"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        '404':
+          description: "ユーザーが見つからない"
   /auth/login:
     post:
       tags:
         - auth
       operationId: logIn
-      summary: "Google OAuthによるログイン"
+      summary: "ログイン"
       requestBody:
         required: true
         content:
@@ -392,3 +413,36 @@ components:
           description: "アクセストークン"
       required:
         - access_token
+    User:
+      type: object
+      properties:
+        user_id:
+          type: integer
+          format: int64
+          description: "ユーザーの一意のid"
+        user_name:
+          type: string
+          description: "ユーザーのペンネーム"
+        nick_name:
+          type: string
+          description: "ユーザーのニックネーム"
+        birth_year_and_month:
+          type: string
+          description: "ユーザーの生年月（YYYY/MM）"
+        is_anonymous:
+          type: boolean
+          description: "匿名設定"
+        profile_icon_image:
+          type: string
+          description: "ユーザーアイコン画像のurl"
+        good_count:
+          type: integer
+          description: "Good評価の数"
+        created_at:
+          type: string
+          format: date-time
+          description: "ユーザーの作成日時"
+        updated_at:
+          type: string
+          format: date-time
+          description: "ユーザーの修正日時"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -183,6 +183,28 @@ paths:
                 $ref: "#/components/schemas/User"
         '400':
           description: "ユーザー情報の更新に失敗"
+    delete:
+      tags:
+        - users
+      operationId: deleteUserById
+      summary: "IDでユーザーアカウントを削除"
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteUser"
+      responses:
+        '200':
+          description: "ユーザーの削除に成功"
+        '400':
+          description: "ユーザーの削除に失敗"
   /users/{user_id}/posted-novels:
     get:
       tags:
@@ -529,3 +551,12 @@ components:
         profile_icon_image: #追加
           type: string
           description: "ユーザーアイコン画像のurl"
+    DeleteUser:
+      type: object
+      properties:
+        access_token:
+          type: string
+          description: "アクセストークン"
+      required:
+        - user_id
+        - access_token

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -73,14 +73,14 @@ paths:
       tags:
         - novels
       operationId: getNovels
-      summary: "小説一覧を取得"
+      summary: "小説リストを取得"
       responses:
         '200':
-          description: "直近で後続の投稿があったものを先頭にした小説一覧"
+          description: "直近で後続の投稿があったものを先頭にした小説リスト"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Novels"
+                $ref: "#/components/schemas/NovelList"
   /novels/{title_id}:
     get:
       tags:
@@ -95,11 +95,11 @@ paths:
             type: integer
       responses:
         '200':
-          description: "小説IDで取得した小説の概要"
+          description: "小説IDで取得した各小説の概要"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/NovelOverview"
+                $ref: "#/components/schemas/NovelDetail"
         '404':
           description: "小説が見つからない"
   /users: # 不要なAPI？（調査中）
@@ -188,7 +188,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Novels"
+                $ref: "#/components/schemas/NovelList"
         '404':
           description: "ユーザーが見つからない"
   /users/{user_id}:
@@ -217,7 +217,7 @@ paths:
       tags:
         - users
       operationId: getNovelsByUserId
-      summary: "ユーザーが投稿している小説一覧を取得"
+      summary: "ユーザーが投稿している小説リストを取得"
       parameters:
         - name: user_id
           in: path
@@ -226,11 +226,11 @@ paths:
             type: integer
       responses:
         '200':
-          description: "ユーザーIDで取得したユーザーが投稿している小説一覧"
+          description: "ユーザーIDで取得したユーザーが投稿している小説リスト"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Novels"
+                $ref: "#/components/schemas/NovelList"
         '404':
           description: "ユーザーが見つからない"
   /auth/login: # 不要なAPI？（調査中）
@@ -358,7 +358,7 @@ components:
           type: integer
           format: int64
           description: "Stay評価の数"
-    Novel:
+    NovelListItem:
       type: object
       properties:
         title_id:
@@ -406,13 +406,13 @@ components:
           type: string
           format: date-time
           description: "小説の修正日時"
-    Novels:
+    NovelList:
       type: array
       items:
-        $ref: "#/components/schemas/Novel"
-    NovelOverview:
+        $ref: "#/components/schemas/NovelListItem"
+    NovelDetail:
       allOf:
-        - $ref: "#/components/schemas/Novel"
+        - $ref: "#/components/schemas/NovelListItem"
         - type: object
           properties:
             main_copy:
@@ -429,7 +429,7 @@ components:
               description: "小説を読んだユーザーの数"
             overview:
               type: string
-              description: "小説の概要"
+              description: "小説のあらすじ"
     RegisterUser:
       type: object
       properties:

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -136,6 +136,44 @@ paths:
                 $ref: "#/components/schemas/RegisterUserResult"
         '400':
           description: "ユーザー登録に失敗"
+  /auth/login:
+    post:
+      tags:
+        - auth
+      operationId: logIn
+      summary: "Google OAuthによるログイン"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+      responses:
+        '200':
+          description: "ログイン成功"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+        '401':
+          description: "認証失敗"
+  /auth/logout:
+    post:
+      tags:
+        - auth
+      operationId: logOut
+      summary: "ログアウト"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LogoutRequest"
+      responses:
+        '200':
+          description: "ログアウト成功"
+        '401':
+          description: "認証失敗"
 components:
   schemas:
     Sentence:
@@ -325,3 +363,29 @@ components:
               type: string
               format: date-time
               description: "ユーザーの作成日時"
+    LoginRequest:
+      type: object
+      properties:
+        google_token:
+          type: string
+          description: "Google OAuthのトークン"
+      required:
+        - google_token
+    LoginResponse:
+      type: object
+      properties:
+        user_id:
+          type: integer
+          format: int64
+          description: "ユーザーの一意のID"
+        access_token:
+          type: string
+          description: "アクセストークン"
+    LogoutRequest:
+      type: object
+      properties:
+        access_token:
+          type: string
+          description: "アクセストークン"
+      required:
+        - access_token

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -10,7 +10,7 @@ paths:
       tags:
         - sentences
       operationId: getSentenceById
-      summary: Get a sentence by ID
+      summary: "IDで投稿を取得"
       parameters:
         - name: sentence_id
           in: path
@@ -19,13 +19,13 @@ paths:
             type: integer
       responses:
         '200':
-          description: A single sentence
+          description: "投稿IDで取得した投稿および関連投稿"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ViewSentence"
         '404':
-          description: Sentence not found
+          description: "投稿が見つかりません"
 components:
   schemas:
     Sentence:

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -25,7 +25,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ViewSentence"
         '404':
-          description: "投稿が見つかりません"
+          description: "投稿が見つからない"
     post:
       tags:
         - sentences
@@ -37,6 +37,7 @@ paths:
           required: true
           schema:
             type: integer
+            format: int64
       requestBody:
         required: true
         content:
@@ -45,13 +46,41 @@ paths:
               $ref: "#/components/schemas/PostSentence"
       responses:
         '201':
-          description: "投稿が作成されました"
+          description: "新規投稿の追加に成功"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ViewSentence"
         '400':
-          description: "投稿に失敗しました"
+          description: "新規投稿の追加に失敗"
+  /evaluations/{sentence_id}:
+    post:
+      tags:
+        - evaluations
+      operationId: evaluateSentence
+      summary: "投稿に対する評価を追加"
+      parameters:
+        - name: sentence_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EvaluateSentence"
+      responses:
+        '201':
+          description: "評価の追加に成功"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ViewEvaluation"
+        '400':
+          description: "評価の追加に失敗"
 components:
   schemas:
     Sentence:
@@ -121,3 +150,33 @@ components:
         sentence:
           type: string
           description: "新投稿の本文テキスト"
+    EvaluateSentence:
+      type: object
+      properties:
+        sentence_id:
+          type: integer
+          format: int64
+          description: "評価対象の投稿のID"
+        evaluator_user_id:
+          type: integer
+          format: int64
+          description: "評価を行ったユーザーのID"
+        evaluation:
+          type: string
+          enum: [good, bad, stay]
+          description: "評価の種類"
+    ViewEvaluation:
+      type: object
+      properties:
+        sentence_id:
+          type: integer
+          format: int64
+          description: "評価対象の投稿のID"
+        evaluation_good_count:
+          type: integer
+          format: int64
+          description: "Good評価の数"
+        evaluation_stay_count:
+          type: integer
+          format: int64
+          description: "Stay評価の数"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -26,6 +26,32 @@ paths:
                 $ref: "#/components/schemas/ViewSentence"
         '404':
           description: "投稿が見つかりません"
+    post:
+      tags:
+        - sentences
+      operationId: postSentence
+      summary: "投稿IDの続きの新規投稿を作成"
+      parameters:
+        - name: sentence_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PostSentence"
+      responses:
+        '201':
+          description: "投稿が作成されました"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ViewSentence"
+        '400':
+          description: "投稿に失敗しました"
 components:
   schemas:
     Sentence:
@@ -41,7 +67,7 @@ components:
         sentence_user_id:
           type: integer
           format: int64
-          description: "投稿の親投稿のid"
+          description: "投稿ユーザーのid"
         sentence_user_name:
           type: string
           description: "投稿ユーザーのペンネーム"
@@ -77,3 +103,21 @@ components:
           $ref: "#/components/schemas/Sentences"
         children:
           $ref: "#/components/schemas/Sentences"
+    PostSentence:
+      type: object
+      properties:
+        parent_sentence_id:
+          type: integer
+          format: int64
+          description: "親投稿のid"
+        parent_sentence_user_id:
+          type: integer
+          format: int64
+          description: "親投稿のユーザーid"
+        sentence_user_id:
+          type: integer
+          format: int64
+          description: "新投稿のユーザーid"
+        sentence:
+          type: string
+          description: "新投稿の本文テキスト"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -81,6 +81,40 @@ paths:
                 $ref: "#/components/schemas/ViewEvaluation"
         '400':
           description: "評価の追加に失敗"
+  /novels/:
+    get:
+      tags:
+        - novels
+      operationId: getNovels
+      summary: "小説一覧を取得"
+      responses:
+        '200':
+          description: "小説一覧"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Novels"
+  /novels/{title_id}:
+    get:
+      tags:
+        - novels
+      operationId: getNovelById
+      summary: "IDで小説の概要を取得"
+      parameters:
+        - name: title_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: "小説IDで取得した小説"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NovelOverview"
+        '404':
+          description: "小説が見つからない"
 components:
   schemas:
     Sentence:
@@ -180,3 +214,69 @@ components:
           type: integer
           format: int64
           description: "Stay評価の数"
+    Novel:
+      type: object
+      properties:
+        title_id:
+          type: integer
+          format: int64
+          description: "小説の一意のid（この値は他の小説と重複しない必要があります）"
+        title:
+          type: string
+          description: "小説のタイトル"
+        main_copy:
+          type: string
+          description: "小説の紹介文"
+        author_user_id:
+          type: integer
+          format: int64
+          description: "小説の作者のid"
+        author_user_name:
+          type: string
+          description: "小説の作者のペンネーム"
+        profile_icon_image:
+          type: string
+          description: "小説の作者のアイコン画像のurl"
+        title_genres:
+          type: array
+          items:
+            type: string
+          description: "小説のジャンル"
+        is_new:
+          type: boolean
+          description: "新着小説かどうか"
+        is_famous:
+          type: boolean
+          description: "人気小説かどうか"
+        view_count:
+          type: integer
+          description: "小説の閲覧数"
+        created_at:
+          type: string
+          format: date-time
+          description: "小説の作成日時"
+        updated_at:
+          type: string
+          format: date-time
+          description: "小説の修正日時"
+    Novels:
+      type: array
+      items:
+        $ref: "#/components/schemas/Novel"
+    NovelOverview:
+      allOf:
+        - $ref: "#/components/schemas/Novel"
+        - type: object
+          properties:
+            sentence_user_count:
+              type: integer
+              description: "小説に投稿された投稿の数"
+            sentence_hierarchy_count:
+              type: integer
+              description: "小説に投稿された投稿の階層数"
+            reader_count:
+              type: integer
+              description: "小説を読んだユーザーの数"
+            overview:
+              type: string
+              description: "小説の概要"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -183,6 +183,48 @@ paths:
                 $ref: "#/components/schemas/User"
         '400':
           description: "ユーザー情報の更新に失敗"
+  /users/{user_id}/posted-novels:
+    get:
+      tags:
+        - users
+      operationId: getNovelsByUserId
+      summary: "ユーザーが投稿している小説一覧を取得"
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: "ユーザーIDで取得したユーザーが投稿している小説一覧"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Novels"
+        '404':
+          description: "ユーザーが見つからない"
+  /users/{user_id}/viewed-novels:
+    get:
+      tags:
+        - users
+      operationId: getViewedNovelsByUserId
+      summary: "ユーザーが閲覧している小説一覧を取得"
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: "ユーザーIDで取得したユーザーが閲覧している小説一覧"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Novels"
+        '404':
+          description: "ユーザーが見つからない"
   /auth/login:
     post:
       tags:

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -138,7 +138,7 @@ paths:
                 $ref: "#/components/schemas/User"
         '400':
           description: "ユーザー情報の更新に失敗"
-  /users/me/delete: # 必要なので残すがrequestBodyは削除
+  /users/me/delete:
     post:
       tags:
         - users
@@ -149,7 +149,7 @@ paths:
           description: "ユーザーの削除に成功"
         '400':
           description: "ユーザーの削除に失敗"
-  /users/me/viewed_novels: #閲覧している小説リストは別のユーザーからは見えない情報でOK？（user_id→meに変更）
+  /users/me/viewed_novels:
     get:
       tags:
         - users
@@ -206,7 +206,7 @@ paths:
                 $ref: "#/components/schemas/NovelList"
         '404':
           description: "ユーザーが見つからない"
-  /auth/logout: # 必要なので残すがrequestBodyは削除（アクセストークンrequestHederで送る）
+  /auth/logout:
     post:
       tags:
         - auth
@@ -332,16 +332,16 @@ components:
           items:
             type: string
           description: "小説のジャンル"
-        is_new: # ブラウザ側で判定するなら不要？
+        is_new:
           type: boolean
           description: "新着小説かどうか"
-        is_famous: # ブラウザ側で判定するなら不要？
+        is_famous:
           type: boolean
           description: "人気小説かどうか"
         view_count:
           type: integer
           description: "小説の閲覧数"
-        evaluation_good_count: # 追加（メダル数を表示しない代わりに）
+        evaluation_good_count:
           type: integer
           description: "小説のGood評価の数"
         created_at:
@@ -426,6 +426,6 @@ components:
         is_anonymous:
           type: boolean
           description: "匿名設定"
-        profile_icon_image: #追加
+        profile_icon_image:
           type: string
           description: "ユーザーアイコン画像のurl"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -283,9 +283,9 @@ components:
         title:
           type: string
           description: "小説のタイトル"
-        main_copy:
+        famous_sentence_text:
           type: string
-          description: "小説の紹介文"
+          description: "名言・印象に残るシーン"
         author_user_id:
           type: integer
           format: int64
@@ -327,6 +327,9 @@ components:
         - $ref: "#/components/schemas/Novel"
         - type: object
           properties:
+            main_copy:
+              type: string
+              description: "小説の紹介文"
             sentence_user_count:
               type: integer
               description: "小説に投稿された投稿の数"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -157,6 +157,32 @@ paths:
                 $ref: "#/components/schemas/User"
         '404':
           description: "ユーザーが見つからない"
+    post: # 部分更新にはpatchの方が適切かも（要検討）
+      tags:
+        - users
+      operationId: updateUserById
+      summary: "IDでユーザーアカウント情報を更新"
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateUser"
+      responses:
+        '200':
+          description: "ユーザー情報の更新に成功"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        '400':
+          description: "ユーザー情報の更新に失敗"
   /auth/login:
     post:
       tags:
@@ -446,3 +472,18 @@ components:
           type: string
           format: date-time
           description: "ユーザーの修正日時"
+    UpdateUser:
+      type: object
+      properties:
+        user_name:
+          type: string
+          description: "ユーザーのペンネーム"
+        nick_name:
+          type: string
+          description: "ユーザーのニックネーム"
+        is_anonymous:
+          type: boolean
+          description: "匿名設定"
+        profile_icon_image: #追加
+          type: string
+          description: "ユーザーアイコン画像のurl"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -102,28 +102,7 @@ paths:
                 $ref: "#/components/schemas/NovelDetail"
         '404':
           description: "小説が見つからない"
-  /users: # 不要なAPI？（調査中）
-    post:
-      tags:
-        - users
-      operationId: registerUser
-      summary: "ユーザー登録"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RegisterUser"
-      responses:
-        '201':
-          description: "ユーザー登録に成功"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RegisterUserResult"
-        '400':
-          description: "ユーザー登録に失敗"
-  /users/me: # 他のユーザーに表示させたくない情報を含むためmeに変更
+  /users/me:
     get:
       tags:
         - users
@@ -138,7 +117,7 @@ paths:
                 $ref: "#/components/schemas/ViewMeUser"
         '404':
           description: "ユーザーが見つからない"
-  /users/me/update: # 他のユーザーにアカウント更新させたくないためmeに変更
+  /users/me/update:
     post:
       tags:
         - users
@@ -159,32 +138,26 @@ paths:
                 $ref: "#/components/schemas/User"
         '400':
           description: "ユーザー情報の更新に失敗"
-  /users/me/delete: # 他のユーザーにアカウント削除させたくないためmeに変更
+  /users/me/delete: # 必要なので残すがrequestBodyは削除
     post:
       tags:
         - users
       operationId:  deleteUserByMe
       summary: "自分自身のユーザーアカウントを削除（論理削除）"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DeleteUser"
       responses:
         '200':
           description: "ユーザーの削除に成功"
         '400':
           description: "ユーザーの削除に失敗"
-  /users/me/viewed_novels: # 他のユーザーに表示させたくない情報を含むためmeに変更
+  /users/me/viewed_novels: #閲覧している小説リストは別のユーザーからは見えない情報でOK？（user_id→meに変更）
     get:
       tags:
         - users
       operationId: getViewedNovelsByMe
-      summary: "自分自身が閲覧している小説一覧を取得"
+      summary: "自分自身が閲覧している小説リストを取得"
       responses:
         '200':
-          description: "自分自身が閲覧している小説一覧"
+          description: "自分自身が閲覧している小説リスト"
           content:
             application/json:
               schema:
@@ -233,39 +206,12 @@ paths:
                 $ref: "#/components/schemas/NovelList"
         '404':
           description: "ユーザーが見つからない"
-  /auth/login: # 不要なAPI？（調査中）
-    post:
-      tags:
-        - auth
-      operationId: logIn
-      summary: "ログイン"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LoginRequest"
-      responses:
-        '200':
-          description: "ログイン成功"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LoginResponse"
-        '401':
-          description: "認証失敗"
-  /auth/logout: # 不要なAPI？（調査中）
+  /auth/logout: # 必要なので残すがrequestBodyは削除（アクセストークンrequestHederで送る）
     post:
       tags:
         - auth
       operationId: logOut
       summary: "ログアウト"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LogoutRequest"
       responses:
         '200':
           description: "ログアウト成功"
@@ -430,56 +376,6 @@ components:
             overview:
               type: string
               description: "小説のあらすじ"
-    RegisterUser:
-      type: object
-      properties:
-        email:
-          type: string
-          format: email
-          description: "ユーザーのメールアドレス"
-        google_sub:
-          type: string
-          maxLength: 128
-          description: "Googleのサブジェクト識別子"
-    RegisterUserResult:
-      allOf:
-        - $ref: "#/components/schemas/RegisterUser"
-        - type: object
-          properties:
-            user_id:
-              type: integer
-              format: int64
-              description: "ユーザーの一意のid"
-            created_at:
-              type: string
-              format: date-time
-              description: "ユーザーの作成日時"
-    LoginRequest:
-      type: object
-      properties:
-        google_token:
-          type: string
-          description: "Google OAuthのトークン"
-      required:
-        - google_token
-    LoginResponse:
-      type: object
-      properties:
-        user_id:
-          type: integer
-          format: int64
-          description: "ユーザーの一意のID"
-        access_token:
-          type: string
-          description: "アクセストークン"
-    LogoutRequest:
-      type: object
-      properties:
-        access_token:
-          type: string
-          description: "アクセストークン"
-      required:
-        - access_token
     User:
       type: object
       properties:
@@ -533,12 +429,3 @@ components:
         profile_icon_image: #追加
           type: string
           description: "ユーザーアイコン画像のurl"
-    DeleteUser:
-      type: object
-      properties:
-        access_token:
-          type: string
-          description: "アクセストークン"
-      required:
-        - user_id
-        - access_token

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -264,7 +264,7 @@ components:
           $ref: "#/components/schemas/Sentence"
         parent:
           $ref: "#/components/schemas/Sentence"
-        parentParallel:
+        parent_parallel:
           $ref: "#/components/schemas/Sentences"
         children:
           $ref: "#/components/schemas/Sentences"

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -215,6 +215,7 @@ font-style: italic;
   </ul>
   <h4><a href="#Users">Users</a></h4>
   <ul>
+  <li><a href="#deleteUserById"><code><span class="http-method">delete</span> /users/{user_id}</code></a></li>
   <li><a href="#getNovelsByUserId"><code><span class="http-method">get</span> /users/{user_id}/posted-novels</code></a></li>
   <li><a href="#getUserById"><code><span class="http-method">get</span> /users/{user_id}</code></a></li>
   <li><a href="#getViewedNovelsByUserId"><code><span class="http-method">get</span> /users/{user_id}/viewed-novels</code></a></li>
@@ -750,6 +751,51 @@ font-style: italic;
   </div> <!-- method -->
   <hr/>
   <h1><a name="Users">Users</a></h1>
+  <div class="method"><a name="deleteUserById"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="delete"><code class="huge"><span class="http-method">delete</span> /users/{user_id}</code></pre></div>
+    <div class="method-summary">IDでユーザーアカウントを削除 (<span class="nickname">deleteUserById</span>)</div>
+    <div class="method-notes"></div>
+
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">user_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
+    </div>  <!-- field-items -->
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">DeleteUser <a href="#DeleteUser">DeleteUser</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    ユーザーの削除に成功
+        <a href="#"></a>
+    <h4 class="field-label">400</h4>
+    ユーザーの削除に失敗
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="getNovelsByUserId"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -1086,6 +1132,7 @@ font-style: italic;
 
   <h3>Table of Contents</h3>
   <ol>
+    <li><a href="#DeleteUser"><code>DeleteUser</code> - </a></li>
     <li><a href="#EvaluateSentence"><code>EvaluateSentence</code> - </a></li>
     <li><a href="#LoginRequest"><code>LoginRequest</code> - </a></li>
     <li><a href="#LoginResponse"><code>LoginResponse</code> - </a></li>
@@ -1102,6 +1149,13 @@ font-style: italic;
     <li><a href="#ViewSentence"><code>ViewSentence</code> - </a></li>
   </ol>
 
+  <div class="model">
+    <h3><a name="DeleteUser"><code>DeleteUser</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">access_token </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> アクセストークン </div>
+    </div>  <!-- field-items -->
+  </div>
   <div class="model">
     <h3><a name="EvaluateSentence"><code>EvaluateSentence</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -196,7 +196,6 @@ font-style: italic;
   <div class="method-summary"></div>
   <h4><a href="#Auth">Auth</a></h4>
   <ul>
-  <li><a href="#logIn"><code><span class="http-method">post</span> /auth/login</code></a></li>
   <li><a href="#logOut"><code><span class="http-method">post</span> /auth/logout</code></a></li>
   </ul>
   <h4><a href="#Evaluations">Evaluations</a></h4>
@@ -220,67 +219,10 @@ font-style: italic;
   <li><a href="#getUserById"><code><span class="http-method">get</span> /users/{user_id}</code></a></li>
   <li><a href="#getUserByMe"><code><span class="http-method">get</span> /users/me</code></a></li>
   <li><a href="#getViewedNovelsByMe"><code><span class="http-method">get</span> /users/me/viewed_novels</code></a></li>
-  <li><a href="#registerUser"><code><span class="http-method">post</span> /users</code></a></li>
   <li><a href="#updateUserByMe"><code><span class="http-method">post</span> /users/me/update</code></a></li>
   </ul>
 
   <h1><a name="Auth">Auth</a></h1>
-  <div class="method"><a name="logIn"/>
-    <div class="method-path">
-    <a class="up" href="#__Methods">Up</a>
-    <pre class="post"><code class="huge"><span class="http-method">post</span> /auth/login</code></pre></div>
-    <div class="method-summary">ログイン (<span class="nickname">logIn</span>)</div>
-    <div class="method-notes"></div>
-
-
-    <h3 class="field-label">Consumes</h3>
-    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
-    <ul>
-      <li><code>application/json</code></li>
-    </ul>
-
-    <h3 class="field-label">Request body</h3>
-    <div class="field-items">
-      <div class="param">LoginRequest <a href="#LoginRequest">LoginRequest</a> (required)</div>
-
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
-
-    </div>  <!-- field-items -->
-
-
-
-
-    <h3 class="field-label">Return type</h3>
-    <div class="return-type">
-      <a href="#LoginResponse">LoginResponse</a>
-      
-    </div>
-
-    <!--Todo: process Response Object and its headers, schema, examples -->
-
-    <h3 class="field-label">Example data</h3>
-    <div class="example-data-content-type">Content-Type: application/json</div>
-    <pre class="example"><code>{
-  "access_token" : "access_token",
-  "user_id" : 0
-}</code></pre>
-
-    <h3 class="field-label">Produces</h3>
-    This API call produces the following media types according to the <span class="header">Accept</span> request header;
-    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
-    <ul>
-      <li><code>application/json</code></li>
-    </ul>
-
-    <h3 class="field-label">Responses</h3>
-    <h4 class="field-label">200</h4>
-    ログイン成功
-        <a href="#LoginResponse">LoginResponse</a>
-    <h4 class="field-label">401</h4>
-    認証失敗
-        <a href="#"></a>
-  </div> <!-- method -->
-  <hr/>
   <div class="method"><a name="logOut"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -289,19 +231,7 @@ font-style: italic;
     <div class="method-notes"></div>
 
 
-    <h3 class="field-label">Consumes</h3>
-    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
-    <ul>
-      <li><code>application/json</code></li>
-    </ul>
 
-    <h3 class="field-label">Request body</h3>
-    <div class="field-items">
-      <div class="param">LogoutRequest <a href="#LogoutRequest">LogoutRequest</a> (required)</div>
-
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
-
-    </div>  <!-- field-items -->
 
 
 
@@ -751,19 +681,7 @@ font-style: italic;
     <div class="method-notes"></div>
 
 
-    <h3 class="field-label">Consumes</h3>
-    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
-    <ul>
-      <li><code>application/json</code></li>
-    </ul>
 
-    <h3 class="field-label">Request body</h3>
-    <div class="field-items">
-      <div class="param">DeleteUser <a href="#DeleteUser">DeleteUser</a> (required)</div>
-
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
-
-    </div>  <!-- field-items -->
 
 
 
@@ -967,7 +885,7 @@ font-style: italic;
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="get"><code class="huge"><span class="http-method">get</span> /users/me/viewed_novels</code></pre></div>
-    <div class="method-summary">自分自身が閲覧している小説一覧を取得 (<span class="nickname">getViewedNovelsByMe</span>)</div>
+    <div class="method-summary">自分自身が閲覧している小説リストを取得 (<span class="nickname">getViewedNovelsByMe</span>)</div>
     <div class="method-notes"></div>
 
 
@@ -1025,68 +943,10 @@ font-style: italic;
 
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
-    自分自身が閲覧している小説一覧
+    自分自身が閲覧している小説リスト
         
     <h4 class="field-label">404</h4>
     ユーザーが見つからない
-        <a href="#"></a>
-  </div> <!-- method -->
-  <hr/>
-  <div class="method"><a name="registerUser"/>
-    <div class="method-path">
-    <a class="up" href="#__Methods">Up</a>
-    <pre class="post"><code class="huge"><span class="http-method">post</span> /users</code></pre></div>
-    <div class="method-summary">ユーザー登録 (<span class="nickname">registerUser</span>)</div>
-    <div class="method-notes"></div>
-
-
-    <h3 class="field-label">Consumes</h3>
-    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
-    <ul>
-      <li><code>application/json</code></li>
-    </ul>
-
-    <h3 class="field-label">Request body</h3>
-    <div class="field-items">
-      <div class="param">RegisterUser <a href="#RegisterUser">RegisterUser</a> (required)</div>
-
-      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
-
-    </div>  <!-- field-items -->
-
-
-
-
-    <h3 class="field-label">Return type</h3>
-    <div class="return-type">
-      <a href="#RegisterUserResult">RegisterUserResult</a>
-      
-    </div>
-
-    <!--Todo: process Response Object and its headers, schema, examples -->
-
-    <h3 class="field-label">Example data</h3>
-    <div class="example-data-content-type">Content-Type: application/json</div>
-    <pre class="example"><code>{
-  "user_id" : 0,
-  "created_at" : "2000-01-23T04:56:07.000+00:00",
-  "email" : "email",
-  "google_sub" : "google_sub"
-}</code></pre>
-
-    <h3 class="field-label">Produces</h3>
-    This API call produces the following media types according to the <span class="header">Accept</span> request header;
-    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
-    <ul>
-      <li><code>application/json</code></li>
-    </ul>
-
-    <h3 class="field-label">Responses</h3>
-    <h4 class="field-label">201</h4>
-    ユーザー登録に成功
-        <a href="#RegisterUserResult">RegisterUserResult</a>
-    <h4 class="field-label">400</h4>
-    ユーザー登録に失敗
         <a href="#"></a>
   </div> <!-- method -->
   <hr/>
@@ -1157,16 +1017,10 @@ font-style: italic;
 
   <h3>Table of Contents</h3>
   <ol>
-    <li><a href="#DeleteUser"><code>DeleteUser</code> - </a></li>
     <li><a href="#EvaluateSentence"><code>EvaluateSentence</code> - </a></li>
-    <li><a href="#LoginRequest"><code>LoginRequest</code> - </a></li>
-    <li><a href="#LoginResponse"><code>LoginResponse</code> - </a></li>
-    <li><a href="#LogoutRequest"><code>LogoutRequest</code> - </a></li>
     <li><a href="#NovelDetail"><code>NovelDetail</code> - </a></li>
     <li><a href="#NovelListItem"><code>NovelListItem</code> - </a></li>
     <li><a href="#PostSentence"><code>PostSentence</code> - </a></li>
-    <li><a href="#RegisterUser"><code>RegisterUser</code> - </a></li>
-    <li><a href="#RegisterUserResult"><code>RegisterUserResult</code> - </a></li>
     <li><a href="#Sentence"><code>Sentence</code> - </a></li>
     <li><a href="#UpdateUser"><code>UpdateUser</code> - </a></li>
     <li><a href="#User"><code>User</code> - </a></li>
@@ -1176,13 +1030,6 @@ font-style: italic;
   </ol>
 
   <div class="model">
-    <h3><a name="DeleteUser"><code>DeleteUser</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'></div>
-    <div class="field-items">
-      <div class="param">access_token </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> アクセストークン </div>
-    </div>  <!-- field-items -->
-  </div>
-  <div class="model">
     <h3><a name="EvaluateSentence"><code>EvaluateSentence</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
@@ -1190,28 +1037,6 @@ font-style: italic;
 <div class="param">evaluation (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 評価の種類 </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">good</div><div class="param-enum">bad</div><div class="param-enum">stay</div>
-    </div>  <!-- field-items -->
-  </div>
-  <div class="model">
-    <h3><a name="LoginRequest"><code>LoginRequest</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'></div>
-    <div class="field-items">
-      <div class="param">google_token </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Google OAuthのトークン </div>
-    </div>  <!-- field-items -->
-  </div>
-  <div class="model">
-    <h3><a name="LoginResponse"><code>LoginResponse</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'></div>
-    <div class="field-items">
-      <div class="param">user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> ユーザーの一意のID format: int64</div>
-<div class="param">access_token (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> アクセストークン </div>
-    </div>  <!-- field-items -->
-  </div>
-  <div class="model">
-    <h3><a name="LogoutRequest"><code>LogoutRequest</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'></div>
-    <div class="field-items">
-      <div class="param">access_token </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> アクセストークン </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -1263,24 +1088,6 @@ font-style: italic;
     <div class="field-items">
       <div class="param">parent_sentence_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 親投稿のid format: int64</div>
 <div class="param">sentence (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 新投稿の本文テキスト </div>
-    </div>  <!-- field-items -->
-  </div>
-  <div class="model">
-    <h3><a name="RegisterUser"><code>RegisterUser</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'></div>
-    <div class="field-items">
-      <div class="param">email (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのメールアドレス format: email</div>
-<div class="param">google_sub (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Googleのサブジェクト識別子 </div>
-    </div>  <!-- field-items -->
-  </div>
-  <div class="model">
-    <h3><a name="RegisterUserResult"><code>RegisterUserResult</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'></div>
-    <div class="field-items">
-      <div class="param">email (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのメールアドレス format: email</div>
-<div class="param">google_sub (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Googleのサブジェクト識別子 </div>
-<div class="param">user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> ユーザーの一意のid format: int64</div>
-<div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの作成日時 format: date-time</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -204,7 +204,7 @@ font-style: italic;
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="get"><code class="huge"><span class="http-method">get</span> /sentences/{sentence_id}</code></pre></div>
-    <div class="method-summary">Get a sentence by ID (<span class="nickname">getSentenceById</span>)</div>
+    <div class="method-summary">IDで投稿を取得 (<span class="nickname">getSentenceById</span>)</div>
     <div class="method-notes"></div>
 
     <h3 class="field-label">Path parameters</h3>
@@ -305,10 +305,10 @@ font-style: italic;
 
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
-    A single sentence
+    投稿IDで取得した投稿および関連投稿
         <a href="#ViewSentence">ViewSentence</a>
     <h4 class="field-label">404</h4>
-    Sentence not found
+    投稿が見つかりません
         <a href="#"></a>
   </div> <!-- method -->
   <hr/>

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -197,6 +197,7 @@ font-style: italic;
   <h4><a href="#Sentences">Sentences</a></h4>
   <ul>
   <li><a href="#getSentenceById"><code><span class="http-method">get</span> /sentences/{sentence_id}</code></a></li>
+  <li><a href="#postSentence"><code><span class="http-method">post</span> /sentences/{sentence_id}</code></a></li>
   </ul>
 
   <h1><a name="Sentences">Sentences</a></h1>
@@ -312,23 +313,158 @@ font-style: italic;
         <a href="#"></a>
   </div> <!-- method -->
   <hr/>
+  <div class="method"><a name="postSentence"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /sentences/{sentence_id}</code></pre></div>
+    <div class="method-summary">投稿IDの続きの新規投稿を作成 (<span class="nickname">postSentence</span>)</div>
+    <div class="method-notes"></div>
+
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">sentence_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
+    </div>  <!-- field-items -->
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">PostSentence <a href="#PostSentence">PostSentence</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ViewSentence">ViewSentence</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "parentParallel" : [ {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  }, {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  } ],
+  "parent" : {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  },
+  "children" : [ {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  }, {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  } ],
+  "main" : {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  }
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">201</h4>
+    投稿が作成されました
+        <a href="#ViewSentence">ViewSentence</a>
+    <h4 class="field-label">400</h4>
+    投稿に失敗しました
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
 
   <h2><a name="__Models">Models</a></h2>
   [ Jump to <a href="#__Methods">Methods</a> ]
 
   <h3>Table of Contents</h3>
   <ol>
+    <li><a href="#PostSentence"><code>PostSentence</code> - </a></li>
     <li><a href="#Sentence"><code>Sentence</code> - </a></li>
     <li><a href="#ViewSentence"><code>ViewSentence</code> - </a></li>
   </ol>
 
+  <div class="model">
+    <h3><a name="PostSentence"><code>PostSentence</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">parent_sentence_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 親投稿のid format: int64</div>
+<div class="param">parent_sentence_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 親投稿のユーザーid format: int64</div>
+<div class="param">sentence_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 新投稿のユーザーid format: int64</div>
+<div class="param">sentence (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 新投稿の本文テキスト </div>
+    </div>  <!-- field-items -->
+  </div>
   <div class="model">
     <h3><a name="Sentence"><code>Sentence</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">sentence_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 投稿の一意のid（この値は他の投稿と重複しない必要があります） format: int64</div>
 <div class="param">sentence (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 投稿の本文テキスト </div>
-<div class="param">sentence_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 投稿の親投稿のid format: int64</div>
+<div class="param">sentence_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 投稿ユーザーのid format: int64</div>
 <div class="param">sentence_user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 投稿ユーザーのペンネーム </div>
 <div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 投稿ユーザーアイコン画像のurl </div>
 <div class="param">evaluation_good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 投稿に対するGood評価の数 </div>

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -215,6 +215,7 @@ font-style: italic;
   </ul>
   <h4><a href="#Users">Users</a></h4>
   <ul>
+  <li><a href="#getUserById"><code><span class="http-method">get</span> /users/{user_id}</code></a></li>
   <li><a href="#registerUser"><code><span class="http-method">post</span> /users/</code></a></li>
   </ul>
 
@@ -223,7 +224,7 @@ font-style: italic;
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="post"><code class="huge"><span class="http-method">post</span> /auth/login</code></pre></div>
-    <div class="method-summary">Google OAuthによるログイン (<span class="nickname">logIn</span>)</div>
+    <div class="method-summary">ログイン (<span class="nickname">logIn</span>)</div>
     <div class="method-notes"></div>
 
 
@@ -437,7 +438,7 @@ font-style: italic;
 
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
-    小説IDで取得した小説
+    小説IDで取得した小説の概要
         <a href="#NovelOverview">NovelOverview</a>
     <h4 class="field-label">404</h4>
     小説が見つからない
@@ -746,6 +747,63 @@ font-style: italic;
   </div> <!-- method -->
   <hr/>
   <h1><a name="Users">Users</a></h1>
+  <div class="method"><a name="getUserById"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /users/{user_id}</code></pre></div>
+    <div class="method-summary">IDでユーザーアカウント情報を取得 (<span class="nickname">getUserById</span>)</div>
+    <div class="method-notes"></div>
+
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">user_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
+    </div>  <!-- field-items -->
+
+
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#User">User</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "good_count" : 6,
+  "updated_at" : "2000-01-23T04:56:07.000+00:00",
+  "user_id" : 0,
+  "user_name" : "user_name",
+  "is_anonymous" : true,
+  "nick_name" : "nick_name",
+  "birth_year_and_month" : "birth_year_and_month",
+  "profile_icon_image" : "profile_icon_image",
+  "created_at" : "2000-01-23T04:56:07.000+00:00"
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    ユーザーIDで取得したユーザーアカウント情報
+        <a href="#User">User</a>
+    <h4 class="field-label">404</h4>
+    ユーザーが見つからない
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="registerUser"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -820,6 +878,7 @@ font-style: italic;
     <li><a href="#RegisterUser"><code>RegisterUser</code> - </a></li>
     <li><a href="#RegisterUserResult"><code>RegisterUserResult</code> - </a></li>
     <li><a href="#Sentence"><code>Sentence</code> - </a></li>
+    <li><a href="#User"><code>User</code> - </a></li>
     <li><a href="#ViewEvaluation"><code>ViewEvaluation</code> - </a></li>
     <li><a href="#ViewSentence"><code>ViewSentence</code> - </a></li>
   </ol>
@@ -939,6 +998,21 @@ font-style: italic;
 <div class="param">evaluation_stay_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 投稿に対するStay評価の数 </div>
 <div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 投稿日時 format: date-time</div>
 <div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 修正日時 format: date-time</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="User"><code>User</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> ユーザーの一意のid format: int64</div>
+<div class="param">user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのペンネーム </div>
+<div class="param">nick_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのニックネーム </div>
+<div class="param">birth_year_and_month (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーの生年月（YYYY/MM） </div>
+<div class="param">is_anonymous (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 匿名設定 </div>
+<div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーアイコン画像のurl </div>
+<div class="param">good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> Good評価の数 </div>
+<div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの作成日時 format: date-time</div>
+<div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの修正日時 format: date-time</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -472,7 +472,18 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "parentParallel" : [ {
+  "parent" : {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  },
+  "children" : [ {
     "sentence" : "sentence",
     "updated_at" : "2000-01-23T04:56:07.000+00:00",
     "sentence_id" : 0,
@@ -493,18 +504,7 @@ font-style: italic;
     "evaluation_stay_count" : 5,
     "sentence_user_name" : "sentence_user_name"
   } ],
-  "parent" : {
-    "sentence" : "sentence",
-    "updated_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_id" : 0,
-    "profile_icon_image" : "profile_icon_image",
-    "evaluation_good_count" : 1,
-    "created_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_user_id" : 6,
-    "evaluation_stay_count" : 5,
-    "sentence_user_name" : "sentence_user_name"
-  },
-  "children" : [ {
+  "parent_parallel" : [ {
     "sentence" : "sentence",
     "updated_at" : "2000-01-23T04:56:07.000+00:00",
     "sentence_id" : 0,
@@ -590,7 +590,18 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "parentParallel" : [ {
+  "parent" : {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  },
+  "children" : [ {
     "sentence" : "sentence",
     "updated_at" : "2000-01-23T04:56:07.000+00:00",
     "sentence_id" : 0,
@@ -611,18 +622,7 @@ font-style: italic;
     "evaluation_stay_count" : 5,
     "sentence_user_name" : "sentence_user_name"
   } ],
-  "parent" : {
-    "sentence" : "sentence",
-    "updated_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_id" : 0,
-    "profile_icon_image" : "profile_icon_image",
-    "evaluation_good_count" : 1,
-    "created_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_user_id" : 6,
-    "evaluation_stay_count" : 5,
-    "sentence_user_name" : "sentence_user_name"
-  },
-  "children" : [ {
+  "parent_parallel" : [ {
     "sentence" : "sentence",
     "updated_at" : "2000-01-23T04:56:07.000+00:00",
     "sentence_id" : 0,
@@ -1158,7 +1158,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">main (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">Sentence</a></span>  </div>
 <div class="param">parent (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">Sentence</a></span>  </div>
-<div class="param">parentParallel (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">array[Sentence]</a></span>  </div>
+<div class="param">parent_parallel (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">array[Sentence]</a></span>  </div>
 <div class="param">children (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">array[Sentence]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -194,12 +194,80 @@ font-style: italic;
 
   <h3>Table of Contents </h3>
   <div class="method-summary"></div>
+  <h4><a href="#Evaluations">Evaluations</a></h4>
+  <ul>
+  <li><a href="#evaluateSentence"><code><span class="http-method">post</span> /evaluations/{sentence_id}</code></a></li>
+  </ul>
   <h4><a href="#Sentences">Sentences</a></h4>
   <ul>
   <li><a href="#getSentenceById"><code><span class="http-method">get</span> /sentences/{sentence_id}</code></a></li>
   <li><a href="#postSentence"><code><span class="http-method">post</span> /sentences/{sentence_id}</code></a></li>
   </ul>
 
+  <h1><a name="Evaluations">Evaluations</a></h1>
+  <div class="method"><a name="evaluateSentence"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /evaluations/{sentence_id}</code></pre></div>
+    <div class="method-summary">投稿に対する評価を追加 (<span class="nickname">evaluateSentence</span>)</div>
+    <div class="method-notes"></div>
+
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">sentence_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null format: int64</div>
+    </div>  <!-- field-items -->
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">EvaluateSentence <a href="#EvaluateSentence">EvaluateSentence</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ViewEvaluation">ViewEvaluation</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "sentence_id" : 0,
+  "evaluation_good_count" : 6,
+  "evaluation_stay_count" : 1
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">201</h4>
+    評価の追加に成功
+        <a href="#ViewEvaluation">ViewEvaluation</a>
+    <h4 class="field-label">400</h4>
+    評価の追加に失敗
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
   <h1><a name="Sentences">Sentences</a></h1>
   <div class="method"><a name="getSentenceById"/>
     <div class="method-path">
@@ -309,7 +377,7 @@ font-style: italic;
     投稿IDで取得した投稿および関連投稿
         <a href="#ViewSentence">ViewSentence</a>
     <h4 class="field-label">404</h4>
-    投稿が見つかりません
+    投稿が見つからない
         <a href="#"></a>
   </div> <!-- method -->
   <hr/>
@@ -324,7 +392,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">sentence_id (required)</div>
 
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null format: int64</div>
     </div>  <!-- field-items -->
 
     <h3 class="field-label">Consumes</h3>
@@ -430,10 +498,10 @@ font-style: italic;
 
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">201</h4>
-    投稿が作成されました
+    新規投稿の追加に成功
         <a href="#ViewSentence">ViewSentence</a>
     <h4 class="field-label">400</h4>
-    投稿に失敗しました
+    新規投稿の追加に失敗
         <a href="#"></a>
   </div> <!-- method -->
   <hr/>
@@ -443,11 +511,24 @@ font-style: italic;
 
   <h3>Table of Contents</h3>
   <ol>
+    <li><a href="#EvaluateSentence"><code>EvaluateSentence</code> - </a></li>
     <li><a href="#PostSentence"><code>PostSentence</code> - </a></li>
     <li><a href="#Sentence"><code>Sentence</code> - </a></li>
+    <li><a href="#ViewEvaluation"><code>ViewEvaluation</code> - </a></li>
     <li><a href="#ViewSentence"><code>ViewSentence</code> - </a></li>
   </ol>
 
+  <div class="model">
+    <h3><a name="EvaluateSentence"><code>EvaluateSentence</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">sentence_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 評価対象の投稿のID format: int64</div>
+<div class="param">evaluator_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 評価を行ったユーザーのID format: int64</div>
+<div class="param">evaluation (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 評価の種類 </div>
+        <div class="param-enum-header">Enum:</div>
+        <div class="param-enum">good</div><div class="param-enum">bad</div><div class="param-enum">stay</div>
+    </div>  <!-- field-items -->
+  </div>
   <div class="model">
     <h3><a name="PostSentence"><code>PostSentence</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
@@ -471,6 +552,15 @@ font-style: italic;
 <div class="param">evaluation_stay_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 投稿に対するStay評価の数 </div>
 <div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 投稿日時 format: date-time</div>
 <div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 修正日時 format: date-time</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="ViewEvaluation"><code>ViewEvaluation</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">sentence_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 評価対象の投稿のID format: int64</div>
+<div class="param">evaluation_good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> Good評価の数 format: int64</div>
+<div class="param">evaluation_stay_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> Stay評価の数 format: int64</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -198,6 +198,11 @@ font-style: italic;
   <ul>
   <li><a href="#evaluateSentence"><code><span class="http-method">post</span> /evaluations/{sentence_id}</code></a></li>
   </ul>
+  <h4><a href="#Novels">Novels</a></h4>
+  <ul>
+  <li><a href="#getNovelById"><code><span class="http-method">get</span> /novels/{title_id}</code></a></li>
+  <li><a href="#getNovels"><code><span class="http-method">get</span> /novels/</code></a></li>
+  </ul>
   <h4><a href="#Sentences">Sentences</a></h4>
   <ul>
   <li><a href="#getSentenceById"><code><span class="http-method">get</span> /sentences/{sentence_id}</code></a></li>
@@ -266,6 +271,135 @@ font-style: italic;
     <h4 class="field-label">400</h4>
     評価の追加に失敗
         <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <h1><a name="Novels">Novels</a></h1>
+  <div class="method"><a name="getNovelById"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /novels/{title_id}</code></pre></div>
+    <div class="method-summary">IDで小説の概要を取得 (<span class="nickname">getNovelById</span>)</div>
+    <div class="method-notes"></div>
+
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">title_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
+    </div>  <!-- field-items -->
+
+
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#NovelOverview">NovelOverview</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "overview" : "overview",
+  "is_new" : true,
+  "title_id" : 0,
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "sentence_user_count" : 5,
+  "is_famous" : true,
+  "author_user_name" : "author_user_name",
+  "updated_at" : "2000-01-23T04:56:07.000+00:00",
+  "author_user_id" : 6,
+  "reader_count" : 2,
+  "profile_icon_image" : "profile_icon_image",
+  "main_copy" : "main_copy",
+  "sentence_hierarchy_count" : 5,
+  "view_count" : 1
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    小説IDで取得した小説
+        <a href="#NovelOverview">NovelOverview</a>
+    <h4 class="field-label">404</h4>
+    小説が見つからない
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="getNovels"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /novels/</code></pre></div>
+    <div class="method-summary">小説一覧を取得 (<span class="nickname">getNovels</span>)</div>
+    <div class="method-notes"></div>
+
+
+
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      array[<a href="#Novel">Novel</a>]
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>[ {
+  "is_famous" : true,
+  "author_user_name" : "author_user_name",
+  "updated_at" : "2000-01-23T04:56:07.000+00:00",
+  "author_user_id" : 6,
+  "is_new" : true,
+  "title_id" : 0,
+  "profile_icon_image" : "profile_icon_image",
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "main_copy" : "main_copy",
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "view_count" : 1
+}, {
+  "is_famous" : true,
+  "author_user_name" : "author_user_name",
+  "updated_at" : "2000-01-23T04:56:07.000+00:00",
+  "author_user_id" : 6,
+  "is_new" : true,
+  "title_id" : 0,
+  "profile_icon_image" : "profile_icon_image",
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "main_copy" : "main_copy",
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "view_count" : 1
+} ]</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    小説一覧
+        
   </div> <!-- method -->
   <hr/>
   <h1><a name="Sentences">Sentences</a></h1>
@@ -512,6 +646,8 @@ font-style: italic;
   <h3>Table of Contents</h3>
   <ol>
     <li><a href="#EvaluateSentence"><code>EvaluateSentence</code> - </a></li>
+    <li><a href="#Novel"><code>Novel</code> - </a></li>
+    <li><a href="#NovelOverview"><code>NovelOverview</code> - </a></li>
     <li><a href="#PostSentence"><code>PostSentence</code> - </a></li>
     <li><a href="#Sentence"><code>Sentence</code> - </a></li>
     <li><a href="#ViewEvaluation"><code>ViewEvaluation</code> - </a></li>
@@ -527,6 +663,46 @@ font-style: italic;
 <div class="param">evaluation (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 評価の種類 </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">good</div><div class="param-enum">bad</div><div class="param-enum">stay</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="Novel"><code>Novel</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">title_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の一意のid（この値は他の小説と重複しない必要があります） format: int64</div>
+<div class="param">title (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説のタイトル </div>
+<div class="param">main_copy (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の紹介文 </div>
+<div class="param">author_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の作者のid format: int64</div>
+<div class="param">author_user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のペンネーム </div>
+<div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のアイコン画像のurl </div>
+<div class="param">title_genres (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> 小説のジャンル </div>
+<div class="param">is_new (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 新着小説かどうか </div>
+<div class="param">is_famous (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 人気小説かどうか </div>
+<div class="param">view_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説の閲覧数 </div>
+<div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の作成日時 format: date-time</div>
+<div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の修正日時 format: date-time</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="NovelOverview"><code>NovelOverview</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">title_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の一意のid（この値は他の小説と重複しない必要があります） format: int64</div>
+<div class="param">title (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説のタイトル </div>
+<div class="param">main_copy (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の紹介文 </div>
+<div class="param">author_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の作者のid format: int64</div>
+<div class="param">author_user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のペンネーム </div>
+<div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のアイコン画像のurl </div>
+<div class="param">title_genres (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> 小説のジャンル </div>
+<div class="param">is_new (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 新着小説かどうか </div>
+<div class="param">is_famous (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 人気小説かどうか </div>
+<div class="param">view_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説の閲覧数 </div>
+<div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の作成日時 format: date-time</div>
+<div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の修正日時 format: date-time</div>
+<div class="param">sentence_user_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説に投稿された投稿の数 </div>
+<div class="param">sentence_hierarchy_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説に投稿された投稿の階層数 </div>
+<div class="param">reader_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説を読んだユーザーの数 </div>
+<div class="param">overview (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の概要 </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -208,6 +208,10 @@ font-style: italic;
   <li><a href="#getSentenceById"><code><span class="http-method">get</span> /sentences/{sentence_id}</code></a></li>
   <li><a href="#postSentence"><code><span class="http-method">post</span> /sentences/{sentence_id}</code></a></li>
   </ul>
+  <h4><a href="#Users">Users</a></h4>
+  <ul>
+  <li><a href="#registerUser"><code><span class="http-method">post</span> /users/</code></a></li>
+  </ul>
 
   <h1><a name="Evaluations">Evaluations</a></h1>
   <div class="method"><a name="evaluateSentence"/>
@@ -639,6 +643,65 @@ font-style: italic;
         <a href="#"></a>
   </div> <!-- method -->
   <hr/>
+  <h1><a name="Users">Users</a></h1>
+  <div class="method"><a name="registerUser"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /users/</code></pre></div>
+    <div class="method-summary">ユーザー登録 (<span class="nickname">registerUser</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">RegisterUser <a href="#RegisterUser">RegisterUser</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#RegisterUserResult">RegisterUserResult</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "user_id" : 0,
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "email" : "email",
+  "google_sub" : "google_sub"
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">201</h4>
+    ユーザー登録に成功
+        <a href="#RegisterUserResult">RegisterUserResult</a>
+    <h4 class="field-label">400</h4>
+    ユーザー登録に失敗
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
 
   <h2><a name="__Models">Models</a></h2>
   [ Jump to <a href="#__Methods">Methods</a> ]
@@ -649,6 +712,8 @@ font-style: italic;
     <li><a href="#Novel"><code>Novel</code> - </a></li>
     <li><a href="#NovelOverview"><code>NovelOverview</code> - </a></li>
     <li><a href="#PostSentence"><code>PostSentence</code> - </a></li>
+    <li><a href="#RegisterUser"><code>RegisterUser</code> - </a></li>
+    <li><a href="#RegisterUserResult"><code>RegisterUserResult</code> - </a></li>
     <li><a href="#Sentence"><code>Sentence</code> - </a></li>
     <li><a href="#ViewEvaluation"><code>ViewEvaluation</code> - </a></li>
     <li><a href="#ViewSentence"><code>ViewSentence</code> - </a></li>
@@ -713,6 +778,24 @@ font-style: italic;
 <div class="param">parent_sentence_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 親投稿のユーザーid format: int64</div>
 <div class="param">sentence_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 新投稿のユーザーid format: int64</div>
 <div class="param">sentence (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 新投稿の本文テキスト </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="RegisterUser"><code>RegisterUser</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">email (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのメールアドレス format: email</div>
+<div class="param">google_sub (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Googleのサブジェクト識別子 </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="RegisterUserResult"><code>RegisterUserResult</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">email (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのメールアドレス format: email</div>
+<div class="param">google_sub (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Googleのサブジェクト識別子 </div>
+<div class="param">user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> ユーザーの一意のid format: int64</div>
+<div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの作成日時 format: date-time</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -194,6 +194,11 @@ font-style: italic;
 
   <h3>Table of Contents </h3>
   <div class="method-summary"></div>
+  <h4><a href="#Auth">Auth</a></h4>
+  <ul>
+  <li><a href="#logIn"><code><span class="http-method">post</span> /auth/login</code></a></li>
+  <li><a href="#logOut"><code><span class="http-method">post</span> /auth/logout</code></a></li>
+  </ul>
   <h4><a href="#Evaluations">Evaluations</a></h4>
   <ul>
   <li><a href="#evaluateSentence"><code><span class="http-method">post</span> /evaluations/{sentence_id}</code></a></li>
@@ -213,6 +218,102 @@ font-style: italic;
   <li><a href="#registerUser"><code><span class="http-method">post</span> /users/</code></a></li>
   </ul>
 
+  <h1><a name="Auth">Auth</a></h1>
+  <div class="method"><a name="logIn"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /auth/login</code></pre></div>
+    <div class="method-summary">Google OAuthによるログイン (<span class="nickname">logIn</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">LoginRequest <a href="#LoginRequest">LoginRequest</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#LoginResponse">LoginResponse</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "access_token" : "access_token",
+  "user_id" : 0
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    ログイン成功
+        <a href="#LoginResponse">LoginResponse</a>
+    <h4 class="field-label">401</h4>
+    認証失敗
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="logOut"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /auth/logout</code></pre></div>
+    <div class="method-summary">ログアウト (<span class="nickname">logOut</span>)</div>
+    <div class="method-notes"></div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">LogoutRequest <a href="#LogoutRequest">LogoutRequest</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    ログアウト成功
+        <a href="#"></a>
+    <h4 class="field-label">401</h4>
+    認証失敗
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
   <h1><a name="Evaluations">Evaluations</a></h1>
   <div class="method"><a name="evaluateSentence"/>
     <div class="method-path">
@@ -709,6 +810,9 @@ font-style: italic;
   <h3>Table of Contents</h3>
   <ol>
     <li><a href="#EvaluateSentence"><code>EvaluateSentence</code> - </a></li>
+    <li><a href="#LoginRequest"><code>LoginRequest</code> - </a></li>
+    <li><a href="#LoginResponse"><code>LoginResponse</code> - </a></li>
+    <li><a href="#LogoutRequest"><code>LogoutRequest</code> - </a></li>
     <li><a href="#Novel"><code>Novel</code> - </a></li>
     <li><a href="#NovelOverview"><code>NovelOverview</code> - </a></li>
     <li><a href="#PostSentence"><code>PostSentence</code> - </a></li>
@@ -728,6 +832,28 @@ font-style: italic;
 <div class="param">evaluation (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 評価の種類 </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">good</div><div class="param-enum">bad</div><div class="param-enum">stay</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="LoginRequest"><code>LoginRequest</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">google_token </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> Google OAuthのトークン </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="LoginResponse"><code>LoginResponse</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> ユーザーの一意のID format: int64</div>
+<div class="param">access_token (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> アクセストークン </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="LogoutRequest"><code>LogoutRequest</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">access_token </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> アクセストークン </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -416,6 +416,7 @@ font-style: italic;
   "created_at" : "2000-01-23T04:56:07.000+00:00",
   "title" : "title",
   "sentence_user_count" : 5,
+  "famous_sentence_text" : "famous_sentence_text",
   "is_famous" : true,
   "author_user_name" : "author_user_name",
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
@@ -475,10 +476,10 @@ font-style: italic;
   "title_id" : 0,
   "profile_icon_image" : "profile_icon_image",
   "title_genres" : [ "title_genres", "title_genres" ],
-  "main_copy" : "main_copy",
   "created_at" : "2000-01-23T04:56:07.000+00:00",
   "title" : "title",
-  "view_count" : 1
+  "view_count" : 1,
+  "famous_sentence_text" : "famous_sentence_text"
 }, {
   "is_famous" : true,
   "author_user_name" : "author_user_name",
@@ -488,10 +489,10 @@ font-style: italic;
   "title_id" : 0,
   "profile_icon_image" : "profile_icon_image",
   "title_genres" : [ "title_genres", "title_genres" ],
-  "main_copy" : "main_copy",
   "created_at" : "2000-01-23T04:56:07.000+00:00",
   "title" : "title",
-  "view_count" : 1
+  "view_count" : 1,
+  "famous_sentence_text" : "famous_sentence_text"
 } ]</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -862,7 +863,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">title_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の一意のid（この値は他の小説と重複しない必要があります） format: int64</div>
 <div class="param">title (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説のタイトル </div>
-<div class="param">main_copy (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の紹介文 </div>
+<div class="param">famous_sentence_text (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 名言・印象に残るシーン </div>
 <div class="param">author_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の作者のid format: int64</div>
 <div class="param">author_user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のペンネーム </div>
 <div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のアイコン画像のurl </div>
@@ -880,7 +881,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">title_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の一意のid（この値は他の小説と重複しない必要があります） format: int64</div>
 <div class="param">title (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説のタイトル </div>
-<div class="param">main_copy (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の紹介文 </div>
+<div class="param">famous_sentence_text (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 名言・印象に残るシーン </div>
 <div class="param">author_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の作者のid format: int64</div>
 <div class="param">author_user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のペンネーム </div>
 <div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のアイコン画像のurl </div>
@@ -890,6 +891,7 @@ font-style: italic;
 <div class="param">view_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説の閲覧数 </div>
 <div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の作成日時 format: date-time</div>
 <div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の修正日時 format: date-time</div>
+<div class="param">main_copy (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の紹介文 </div>
 <div class="param">sentence_user_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説に投稿された投稿の数 </div>
 <div class="param">sentence_hierarchy_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説に投稿された投稿の階層数 </div>
 <div class="param">reader_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説を読んだユーザーの数 </div>

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -215,7 +215,9 @@ font-style: italic;
   </ul>
   <h4><a href="#Users">Users</a></h4>
   <ul>
+  <li><a href="#getNovelsByUserId"><code><span class="http-method">get</span> /users/{user_id}/posted-novels</code></a></li>
   <li><a href="#getUserById"><code><span class="http-method">get</span> /users/{user_id}</code></a></li>
+  <li><a href="#getViewedNovelsByUserId"><code><span class="http-method">get</span> /users/{user_id}/viewed-novels</code></a></li>
   <li><a href="#registerUser"><code><span class="http-method">post</span> /users/</code></a></li>
   <li><a href="#updateUserById"><code><span class="http-method">post</span> /users/{user_id}</code></a></li>
   </ul>
@@ -748,6 +750,79 @@ font-style: italic;
   </div> <!-- method -->
   <hr/>
   <h1><a name="Users">Users</a></h1>
+  <div class="method"><a name="getNovelsByUserId"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /users/{user_id}/posted-novels</code></pre></div>
+    <div class="method-summary">ユーザーが投稿している小説一覧を取得 (<span class="nickname">getNovelsByUserId</span>)</div>
+    <div class="method-notes"></div>
+
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">user_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
+    </div>  <!-- field-items -->
+
+
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      array[<a href="#Novel">Novel</a>]
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>[ {
+  "is_famous" : true,
+  "author_user_name" : "author_user_name",
+  "updated_at" : "2000-01-23T04:56:07.000+00:00",
+  "author_user_id" : 6,
+  "is_new" : true,
+  "title_id" : 0,
+  "profile_icon_image" : "profile_icon_image",
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "view_count" : 1,
+  "famous_sentence_text" : "famous_sentence_text"
+}, {
+  "is_famous" : true,
+  "author_user_name" : "author_user_name",
+  "updated_at" : "2000-01-23T04:56:07.000+00:00",
+  "author_user_id" : 6,
+  "is_new" : true,
+  "title_id" : 0,
+  "profile_icon_image" : "profile_icon_image",
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "view_count" : 1,
+  "famous_sentence_text" : "famous_sentence_text"
+} ]</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    ユーザーIDで取得したユーザーが投稿している小説一覧
+        
+    <h4 class="field-label">404</h4>
+    ユーザーが見つからない
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
   <div class="method"><a name="getUserById"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
@@ -800,6 +875,79 @@ font-style: italic;
     <h4 class="field-label">200</h4>
     ユーザーIDで取得したユーザーアカウント情報
         <a href="#User">User</a>
+    <h4 class="field-label">404</h4>
+    ユーザーが見つからない
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="getViewedNovelsByUserId"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /users/{user_id}/viewed-novels</code></pre></div>
+    <div class="method-summary">ユーザーが閲覧している小説一覧を取得 (<span class="nickname">getViewedNovelsByUserId</span>)</div>
+    <div class="method-notes"></div>
+
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">user_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
+    </div>  <!-- field-items -->
+
+
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      array[<a href="#Novel">Novel</a>]
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>[ {
+  "is_famous" : true,
+  "author_user_name" : "author_user_name",
+  "updated_at" : "2000-01-23T04:56:07.000+00:00",
+  "author_user_id" : 6,
+  "is_new" : true,
+  "title_id" : 0,
+  "profile_icon_image" : "profile_icon_image",
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "view_count" : 1,
+  "famous_sentence_text" : "famous_sentence_text"
+}, {
+  "is_famous" : true,
+  "author_user_name" : "author_user_name",
+  "updated_at" : "2000-01-23T04:56:07.000+00:00",
+  "author_user_id" : 6,
+  "is_new" : true,
+  "title_id" : 0,
+  "profile_icon_image" : "profile_icon_image",
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "view_count" : 1,
+  "famous_sentence_text" : "famous_sentence_text"
+} ]</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    ユーザーIDで取得したユーザーが閲覧している小説一覧
+        
     <h4 class="field-label">404</h4>
     ユーザーが見つからない
         <a href="#"></a>

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -217,6 +217,7 @@ font-style: italic;
   <ul>
   <li><a href="#getUserById"><code><span class="http-method">get</span> /users/{user_id}</code></a></li>
   <li><a href="#registerUser"><code><span class="http-method">post</span> /users/</code></a></li>
+  <li><a href="#updateUserById"><code><span class="http-method">post</span> /users/{user_id}</code></a></li>
   </ul>
 
   <h1><a name="Auth">Auth</a></h1>
@@ -862,6 +863,75 @@ font-style: italic;
         <a href="#"></a>
   </div> <!-- method -->
   <hr/>
+  <div class="method"><a name="updateUserById"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /users/{user_id}</code></pre></div>
+    <div class="method-summary">IDでユーザーアカウント情報を更新 (<span class="nickname">updateUserById</span>)</div>
+    <div class="method-notes"></div>
+
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">user_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
+    </div>  <!-- field-items -->
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">UpdateUser <a href="#UpdateUser">UpdateUser</a> (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+
+    </div>  <!-- field-items -->
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#User">User</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "good_count" : 6,
+  "updated_at" : "2000-01-23T04:56:07.000+00:00",
+  "user_id" : 0,
+  "user_name" : "user_name",
+  "is_anonymous" : true,
+  "nick_name" : "nick_name",
+  "birth_year_and_month" : "birth_year_and_month",
+  "profile_icon_image" : "profile_icon_image",
+  "created_at" : "2000-01-23T04:56:07.000+00:00"
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    ユーザー情報の更新に成功
+        <a href="#User">User</a>
+    <h4 class="field-label">400</h4>
+    ユーザー情報の更新に失敗
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
 
   <h2><a name="__Models">Models</a></h2>
   [ Jump to <a href="#__Methods">Methods</a> ]
@@ -878,6 +948,7 @@ font-style: italic;
     <li><a href="#RegisterUser"><code>RegisterUser</code> - </a></li>
     <li><a href="#RegisterUserResult"><code>RegisterUserResult</code> - </a></li>
     <li><a href="#Sentence"><code>Sentence</code> - </a></li>
+    <li><a href="#UpdateUser"><code>UpdateUser</code> - </a></li>
     <li><a href="#User"><code>User</code> - </a></li>
     <li><a href="#ViewEvaluation"><code>ViewEvaluation</code> - </a></li>
     <li><a href="#ViewSentence"><code>ViewSentence</code> - </a></li>
@@ -998,6 +1069,16 @@ font-style: italic;
 <div class="param">evaluation_stay_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 投稿に対するStay評価の数 </div>
 <div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 投稿日時 format: date-time</div>
 <div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 修正日時 format: date-time</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="UpdateUser"><code>UpdateUser</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのペンネーム </div>
+<div class="param">nick_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのニックネーム </div>
+<div class="param">is_anonymous (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 匿名設定 </div>
+<div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーアイコン画像のurl </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -201,26 +201,27 @@ font-style: italic;
   </ul>
   <h4><a href="#Evaluations">Evaluations</a></h4>
   <ul>
-  <li><a href="#evaluateSentence"><code><span class="http-method">post</span> /evaluations/{sentence_id}</code></a></li>
+  <li><a href="#evaluateSentence"><code><span class="http-method">post</span> /evaluations</code></a></li>
   </ul>
   <h4><a href="#Novels">Novels</a></h4>
   <ul>
   <li><a href="#getNovelById"><code><span class="http-method">get</span> /novels/{title_id}</code></a></li>
-  <li><a href="#getNovels"><code><span class="http-method">get</span> /novels/</code></a></li>
+  <li><a href="#getNovels"><code><span class="http-method">get</span> /novels</code></a></li>
   </ul>
   <h4><a href="#Sentences">Sentences</a></h4>
   <ul>
   <li><a href="#getSentenceById"><code><span class="http-method">get</span> /sentences/{sentence_id}</code></a></li>
-  <li><a href="#postSentence"><code><span class="http-method">post</span> /sentences/{sentence_id}</code></a></li>
+  <li><a href="#postSentence"><code><span class="http-method">post</span> /sentences</code></a></li>
   </ul>
   <h4><a href="#Users">Users</a></h4>
   <ul>
-  <li><a href="#deleteUserById"><code><span class="http-method">delete</span> /users/{user_id}</code></a></li>
-  <li><a href="#getNovelsByUserId"><code><span class="http-method">get</span> /users/{user_id}/posted-novels</code></a></li>
+  <li><a href="#deleteUserByMe"><code><span class="http-method">post</span> /users/me/delete</code></a></li>
+  <li><a href="#getNovelsByUserId"><code><span class="http-method">get</span> /users/{user_id}/posted_novels</code></a></li>
   <li><a href="#getUserById"><code><span class="http-method">get</span> /users/{user_id}</code></a></li>
-  <li><a href="#getViewedNovelsByUserId"><code><span class="http-method">get</span> /users/{user_id}/viewed-novels</code></a></li>
-  <li><a href="#registerUser"><code><span class="http-method">post</span> /users/</code></a></li>
-  <li><a href="#updateUserById"><code><span class="http-method">post</span> /users/{user_id}</code></a></li>
+  <li><a href="#getUserByMe"><code><span class="http-method">get</span> /users/me</code></a></li>
+  <li><a href="#getViewedNovelsByMe"><code><span class="http-method">get</span> /users/me/viewed_novels</code></a></li>
+  <li><a href="#registerUser"><code><span class="http-method">post</span> /users</code></a></li>
+  <li><a href="#updateUserByMe"><code><span class="http-method">post</span> /users/me/update</code></a></li>
   </ul>
 
   <h1><a name="Auth">Auth</a></h1>
@@ -323,7 +324,7 @@ font-style: italic;
   <div class="method"><a name="evaluateSentence"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
-    <pre class="post"><code class="huge"><span class="http-method">post</span> /evaluations/{sentence_id}</code></pre></div>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /evaluations</code></pre></div>
     <div class="method-summary">投稿に対する評価を追加 (<span class="nickname">evaluateSentence</span>)</div>
     <div class="method-notes"></div>
 
@@ -452,7 +453,7 @@ font-style: italic;
   <div class="method"><a name="getNovels"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
-    <pre class="get"><code class="huge"><span class="http-method">get</span> /novels/</code></pre></div>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /novels</code></pre></div>
     <div class="method-summary">小説一覧を取得 (<span class="nickname">getNovels</span>)</div>
     <div class="method-notes"></div>
 
@@ -509,7 +510,7 @@ font-style: italic;
 
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
-    小説一覧
+    直近で後続の投稿があったものを先頭にした小説一覧
         
   </div> <!-- method -->
   <hr/>
@@ -629,8 +630,8 @@ font-style: italic;
   <div class="method"><a name="postSentence"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
-    <pre class="post"><code class="huge"><span class="http-method">post</span> /sentences/{sentence_id}</code></pre></div>
-    <div class="method-summary">投稿IDの続きの新規投稿を作成 (<span class="nickname">postSentence</span>)</div>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /sentences</code></pre></div>
+    <div class="method-summary">メイン投稿の続きの新規投稿を作成 (<span class="nickname">postSentence</span>)</div>
     <div class="method-notes"></div>
 
     <h3 class="field-label">Path parameters</h3>
@@ -751,11 +752,11 @@ font-style: italic;
   </div> <!-- method -->
   <hr/>
   <h1><a name="Users">Users</a></h1>
-  <div class="method"><a name="deleteUserById"/>
+  <div class="method"><a name="deleteUserByMe"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
-    <pre class="delete"><code class="huge"><span class="http-method">delete</span> /users/{user_id}</code></pre></div>
-    <div class="method-summary">IDでユーザーアカウントを削除 (<span class="nickname">deleteUserById</span>)</div>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /users/me/delete</code></pre></div>
+    <div class="method-summary">自分自身のユーザーアカウントを削除（論理削除） (<span class="nickname">deleteUserByMe</span>)</div>
     <div class="method-notes"></div>
 
     <h3 class="field-label">Path parameters</h3>
@@ -799,7 +800,7 @@ font-style: italic;
   <div class="method"><a name="getNovelsByUserId"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
-    <pre class="get"><code class="huge"><span class="http-method">get</span> /users/{user_id}/posted-novels</code></pre></div>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /users/{user_id}/posted_novels</code></pre></div>
     <div class="method-summary">ユーザーが投稿している小説一覧を取得 (<span class="nickname">getNovelsByUserId</span>)</div>
     <div class="method-notes"></div>
 
@@ -873,7 +874,7 @@ font-style: italic;
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="get"><code class="huge"><span class="http-method">get</span> /users/{user_id}</code></pre></div>
-    <div class="method-summary">IDでユーザーアカウント情報を取得 (<span class="nickname">getUserById</span>)</div>
+    <div class="method-summary">IDで自分以外のユーザーアカウント情報を取得 (<span class="nickname">getUserById</span>)</div>
     <div class="method-notes"></div>
 
     <h3 class="field-label">Path parameters</h3>
@@ -903,9 +904,7 @@ font-style: italic;
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "user_id" : 0,
   "user_name" : "user_name",
-  "is_anonymous" : true,
   "nick_name" : "nick_name",
-  "birth_year_and_month" : "birth_year_and_month",
   "profile_icon_image" : "profile_icon_image",
   "created_at" : "2000-01-23T04:56:07.000+00:00"
 }</code></pre>
@@ -926,11 +925,68 @@ font-style: italic;
         <a href="#"></a>
   </div> <!-- method -->
   <hr/>
-  <div class="method"><a name="getViewedNovelsByUserId"/>
+  <div class="method"><a name="getUserByMe"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
-    <pre class="get"><code class="huge"><span class="http-method">get</span> /users/{user_id}/viewed-novels</code></pre></div>
-    <div class="method-summary">ユーザーが閲覧している小説一覧を取得 (<span class="nickname">getViewedNovelsByUserId</span>)</div>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /users/me</code></pre></div>
+    <div class="method-summary">自分自身のユーザーアカウント情報を取得 (<span class="nickname">getUserByMe</span>)</div>
+    <div class="method-notes"></div>
+
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">user_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
+    </div>  <!-- field-items -->
+
+
+
+
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ViewMeUser">ViewMeUser</a>
+      
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "good_count" : 6,
+  "updated_at" : "2000-01-23T04:56:07.000+00:00",
+  "user_id" : 0,
+  "user_name" : "user_name",
+  "is_anonymous" : true,
+  "nick_name" : "nick_name",
+  "birth_year_and_month" : "birth_year_and_month",
+  "profile_icon_image" : "profile_icon_image",
+  "created_at" : "2000-01-23T04:56:07.000+00:00"
+}</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    自分自身のユーザーアカウント情報
+        <a href="#ViewMeUser">ViewMeUser</a>
+    <h4 class="field-label">404</h4>
+    ユーザーが見つからない
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="getViewedNovelsByMe"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /users/me/viewed_novels</code></pre></div>
+    <div class="method-summary">自分自身が閲覧している小説一覧を取得 (<span class="nickname">getViewedNovelsByMe</span>)</div>
     <div class="method-notes"></div>
 
     <h3 class="field-label">Path parameters</h3>
@@ -992,7 +1048,7 @@ font-style: italic;
 
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
-    ユーザーIDで取得したユーザーが閲覧している小説一覧
+    自分自身が閲覧している小説一覧
         
     <h4 class="field-label">404</h4>
     ユーザーが見つからない
@@ -1002,7 +1058,7 @@ font-style: italic;
   <div class="method"><a name="registerUser"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
-    <pre class="post"><code class="huge"><span class="http-method">post</span> /users/</code></pre></div>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /users</code></pre></div>
     <div class="method-summary">ユーザー登録 (<span class="nickname">registerUser</span>)</div>
     <div class="method-notes"></div>
 
@@ -1057,11 +1113,11 @@ font-style: italic;
         <a href="#"></a>
   </div> <!-- method -->
   <hr/>
-  <div class="method"><a name="updateUserById"/>
+  <div class="method"><a name="updateUserByMe"/>
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
-    <pre class="post"><code class="huge"><span class="http-method">post</span> /users/{user_id}</code></pre></div>
-    <div class="method-summary">IDでユーザーアカウント情報を更新 (<span class="nickname">updateUserById</span>)</div>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /users/me/update</code></pre></div>
+    <div class="method-summary">自分自身のユーザーアカウント情報を更新 (<span class="nickname">updateUserByMe</span>)</div>
     <div class="method-notes"></div>
 
     <h3 class="field-label">Path parameters</h3>
@@ -1103,9 +1159,7 @@ font-style: italic;
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "user_id" : 0,
   "user_name" : "user_name",
-  "is_anonymous" : true,
   "nick_name" : "nick_name",
-  "birth_year_and_month" : "birth_year_and_month",
   "profile_icon_image" : "profile_icon_image",
   "created_at" : "2000-01-23T04:56:07.000+00:00"
 }</code></pre>
@@ -1146,6 +1200,7 @@ font-style: italic;
     <li><a href="#UpdateUser"><code>UpdateUser</code> - </a></li>
     <li><a href="#User"><code>User</code> - </a></li>
     <li><a href="#ViewEvaluation"><code>ViewEvaluation</code> - </a></li>
+    <li><a href="#ViewMeUser"><code>ViewMeUser</code> - </a></li>
     <li><a href="#ViewSentence"><code>ViewSentence</code> - </a></li>
   </ol>
 
@@ -1161,7 +1216,6 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">sentence_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 評価対象の投稿のID format: int64</div>
-<div class="param">evaluator_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 評価を行ったユーザーのID format: int64</div>
 <div class="param">evaluation (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 評価の種類 </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">good</div><div class="param-enum">bad</div><div class="param-enum">stay</div>
@@ -1235,8 +1289,6 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">parent_sentence_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 親投稿のid format: int64</div>
-<div class="param">parent_sentence_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 親投稿のユーザーid format: int64</div>
-<div class="param">sentence_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 新投稿のユーザーid format: int64</div>
 <div class="param">sentence (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 新投稿の本文テキスト </div>
     </div>  <!-- field-items -->
   </div>
@@ -1290,8 +1342,6 @@ font-style: italic;
       <div class="param">user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> ユーザーの一意のid format: int64</div>
 <div class="param">user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのペンネーム </div>
 <div class="param">nick_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのニックネーム </div>
-<div class="param">birth_year_and_month (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーの生年月（YYYY/MM） </div>
-<div class="param">is_anonymous (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 匿名設定 </div>
 <div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーアイコン画像のurl </div>
 <div class="param">good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> Good評価の数 </div>
 <div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの作成日時 format: date-time</div>
@@ -1305,6 +1355,21 @@ font-style: italic;
       <div class="param">sentence_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 評価対象の投稿のID format: int64</div>
 <div class="param">evaluation_good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> Good評価の数 format: int64</div>
 <div class="param">evaluation_stay_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> Stay評価の数 format: int64</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="ViewMeUser"><code>ViewMeUser</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> ユーザーの一意のid format: int64</div>
+<div class="param">user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのペンネーム </div>
+<div class="param">nick_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのニックネーム </div>
+<div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーアイコン画像のurl </div>
+<div class="param">good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> Good評価の数 </div>
+<div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの作成日時 format: date-time</div>
+<div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの修正日時 format: date-time</div>
+<div class="param">birth_year_and_month (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーの生年月（YYYY/MM） </div>
+<div class="param">is_anonymous (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 匿名設定 </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -328,12 +328,6 @@ font-style: italic;
     <div class="method-summary">投稿に対する評価を追加 (<span class="nickname">evaluateSentence</span>)</div>
     <div class="method-notes"></div>
 
-    <h3 class="field-label">Path parameters</h3>
-    <div class="field-items">
-      <div class="param">sentence_id (required)</div>
-
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null format: int64</div>
-    </div>  <!-- field-items -->
 
     <h3 class="field-label">Consumes</h3>
     This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
@@ -406,7 +400,7 @@ font-style: italic;
 
     <h3 class="field-label">Return type</h3>
     <div class="return-type">
-      <a href="#NovelOverview">NovelOverview</a>
+      <a href="#NovelDetail">NovelDetail</a>
       
     </div>
 
@@ -427,10 +421,11 @@ font-style: italic;
   "author_user_name" : "author_user_name",
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "author_user_id" : 6,
-  "reader_count" : 2,
+  "reader_count" : 7,
   "profile_icon_image" : "profile_icon_image",
+  "evaluation_good_count" : 5,
   "main_copy" : "main_copy",
-  "sentence_hierarchy_count" : 5,
+  "sentence_hierarchy_count" : 2,
   "view_count" : 1
 }</code></pre>
 
@@ -443,8 +438,8 @@ font-style: italic;
 
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
-    小説IDで取得した小説の概要
-        <a href="#NovelOverview">NovelOverview</a>
+    小説IDで取得した各小説の概要
+        <a href="#NovelDetail">NovelDetail</a>
     <h4 class="field-label">404</h4>
     小説が見つからない
         <a href="#"></a>
@@ -454,7 +449,7 @@ font-style: italic;
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="get"><code class="huge"><span class="http-method">get</span> /novels</code></pre></div>
-    <div class="method-summary">小説一覧を取得 (<span class="nickname">getNovels</span>)</div>
+    <div class="method-summary">小説リストを取得 (<span class="nickname">getNovels</span>)</div>
     <div class="method-notes"></div>
 
 
@@ -465,7 +460,7 @@ font-style: italic;
 
     <h3 class="field-label">Return type</h3>
     <div class="return-type">
-      array[<a href="#Novel">Novel</a>]
+      array[<a href="#NovelListItem">NovelListItem</a>]
       
     </div>
 
@@ -474,31 +469,33 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>[ {
+  "is_new" : true,
+  "title_id" : 0,
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "famous_sentence_text" : "famous_sentence_text",
   "is_famous" : true,
   "author_user_name" : "author_user_name",
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "author_user_id" : 6,
-  "is_new" : true,
-  "title_id" : 0,
   "profile_icon_image" : "profile_icon_image",
-  "title_genres" : [ "title_genres", "title_genres" ],
-  "created_at" : "2000-01-23T04:56:07.000+00:00",
-  "title" : "title",
-  "view_count" : 1,
-  "famous_sentence_text" : "famous_sentence_text"
+  "evaluation_good_count" : 5,
+  "view_count" : 1
 }, {
+  "is_new" : true,
+  "title_id" : 0,
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "famous_sentence_text" : "famous_sentence_text",
   "is_famous" : true,
   "author_user_name" : "author_user_name",
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "author_user_id" : 6,
-  "is_new" : true,
-  "title_id" : 0,
   "profile_icon_image" : "profile_icon_image",
-  "title_genres" : [ "title_genres", "title_genres" ],
-  "created_at" : "2000-01-23T04:56:07.000+00:00",
-  "title" : "title",
-  "view_count" : 1,
-  "famous_sentence_text" : "famous_sentence_text"
+  "evaluation_good_count" : 5,
+  "view_count" : 1
 } ]</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -510,7 +507,7 @@ font-style: italic;
 
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
-    直近で後続の投稿があったものを先頭にした小説一覧
+    直近で後続の投稿があったものを先頭にした小説リスト
         
   </div> <!-- method -->
   <hr/>
@@ -634,12 +631,6 @@ font-style: italic;
     <div class="method-summary">メイン投稿の続きの新規投稿を作成 (<span class="nickname">postSentence</span>)</div>
     <div class="method-notes"></div>
 
-    <h3 class="field-label">Path parameters</h3>
-    <div class="field-items">
-      <div class="param">sentence_id (required)</div>
-
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null format: int64</div>
-    </div>  <!-- field-items -->
 
     <h3 class="field-label">Consumes</h3>
     This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
@@ -759,12 +750,6 @@ font-style: italic;
     <div class="method-summary">自分自身のユーザーアカウントを削除（論理削除） (<span class="nickname">deleteUserByMe</span>)</div>
     <div class="method-notes"></div>
 
-    <h3 class="field-label">Path parameters</h3>
-    <div class="field-items">
-      <div class="param">user_id (required)</div>
-
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
-    </div>  <!-- field-items -->
 
     <h3 class="field-label">Consumes</h3>
     This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
@@ -801,7 +786,7 @@ font-style: italic;
     <div class="method-path">
     <a class="up" href="#__Methods">Up</a>
     <pre class="get"><code class="huge"><span class="http-method">get</span> /users/{user_id}/posted_novels</code></pre></div>
-    <div class="method-summary">ユーザーが投稿している小説一覧を取得 (<span class="nickname">getNovelsByUserId</span>)</div>
+    <div class="method-summary">ユーザーが投稿している小説リストを取得 (<span class="nickname">getNovelsByUserId</span>)</div>
     <div class="method-notes"></div>
 
     <h3 class="field-label">Path parameters</h3>
@@ -818,7 +803,7 @@ font-style: italic;
 
     <h3 class="field-label">Return type</h3>
     <div class="return-type">
-      array[<a href="#Novel">Novel</a>]
+      array[<a href="#NovelListItem">NovelListItem</a>]
       
     </div>
 
@@ -827,31 +812,33 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>[ {
+  "is_new" : true,
+  "title_id" : 0,
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "famous_sentence_text" : "famous_sentence_text",
   "is_famous" : true,
   "author_user_name" : "author_user_name",
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "author_user_id" : 6,
-  "is_new" : true,
-  "title_id" : 0,
   "profile_icon_image" : "profile_icon_image",
-  "title_genres" : [ "title_genres", "title_genres" ],
-  "created_at" : "2000-01-23T04:56:07.000+00:00",
-  "title" : "title",
-  "view_count" : 1,
-  "famous_sentence_text" : "famous_sentence_text"
+  "evaluation_good_count" : 5,
+  "view_count" : 1
 }, {
+  "is_new" : true,
+  "title_id" : 0,
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "famous_sentence_text" : "famous_sentence_text",
   "is_famous" : true,
   "author_user_name" : "author_user_name",
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "author_user_id" : 6,
-  "is_new" : true,
-  "title_id" : 0,
   "profile_icon_image" : "profile_icon_image",
-  "title_genres" : [ "title_genres", "title_genres" ],
-  "created_at" : "2000-01-23T04:56:07.000+00:00",
-  "title" : "title",
-  "view_count" : 1,
-  "famous_sentence_text" : "famous_sentence_text"
+  "evaluation_good_count" : 5,
+  "view_count" : 1
 } ]</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -863,7 +850,7 @@ font-style: italic;
 
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
-    ユーザーIDで取得したユーザーが投稿している小説一覧
+    ユーザーIDで取得したユーザーが投稿している小説リスト
         
     <h4 class="field-label">404</h4>
     ユーザーが見つからない
@@ -900,12 +887,12 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "good_count" : 6,
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "user_id" : 0,
   "user_name" : "user_name",
   "nick_name" : "nick_name",
   "profile_icon_image" : "profile_icon_image",
+  "evaluation_good_count" : 6,
   "created_at" : "2000-01-23T04:56:07.000+00:00"
 }</code></pre>
 
@@ -932,12 +919,6 @@ font-style: italic;
     <div class="method-summary">自分自身のユーザーアカウント情報を取得 (<span class="nickname">getUserByMe</span>)</div>
     <div class="method-notes"></div>
 
-    <h3 class="field-label">Path parameters</h3>
-    <div class="field-items">
-      <div class="param">user_id (required)</div>
-
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
-    </div>  <!-- field-items -->
 
 
 
@@ -955,7 +936,6 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "good_count" : 6,
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "user_id" : 0,
   "user_name" : "user_name",
@@ -963,6 +943,7 @@ font-style: italic;
   "nick_name" : "nick_name",
   "birth_year_and_month" : "birth_year_and_month",
   "profile_icon_image" : "profile_icon_image",
+  "evaluation_good_count" : 6,
   "created_at" : "2000-01-23T04:56:07.000+00:00"
 }</code></pre>
 
@@ -989,12 +970,6 @@ font-style: italic;
     <div class="method-summary">自分自身が閲覧している小説一覧を取得 (<span class="nickname">getViewedNovelsByMe</span>)</div>
     <div class="method-notes"></div>
 
-    <h3 class="field-label">Path parameters</h3>
-    <div class="field-items">
-      <div class="param">user_id (required)</div>
-
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
-    </div>  <!-- field-items -->
 
 
 
@@ -1003,7 +978,7 @@ font-style: italic;
 
     <h3 class="field-label">Return type</h3>
     <div class="return-type">
-      array[<a href="#Novel">Novel</a>]
+      array[<a href="#NovelListItem">NovelListItem</a>]
       
     </div>
 
@@ -1012,31 +987,33 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>[ {
+  "is_new" : true,
+  "title_id" : 0,
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "famous_sentence_text" : "famous_sentence_text",
   "is_famous" : true,
   "author_user_name" : "author_user_name",
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "author_user_id" : 6,
-  "is_new" : true,
-  "title_id" : 0,
   "profile_icon_image" : "profile_icon_image",
-  "title_genres" : [ "title_genres", "title_genres" ],
-  "created_at" : "2000-01-23T04:56:07.000+00:00",
-  "title" : "title",
-  "view_count" : 1,
-  "famous_sentence_text" : "famous_sentence_text"
+  "evaluation_good_count" : 5,
+  "view_count" : 1
 }, {
+  "is_new" : true,
+  "title_id" : 0,
+  "title_genres" : [ "title_genres", "title_genres" ],
+  "created_at" : "2000-01-23T04:56:07.000+00:00",
+  "title" : "title",
+  "famous_sentence_text" : "famous_sentence_text",
   "is_famous" : true,
   "author_user_name" : "author_user_name",
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "author_user_id" : 6,
-  "is_new" : true,
-  "title_id" : 0,
   "profile_icon_image" : "profile_icon_image",
-  "title_genres" : [ "title_genres", "title_genres" ],
-  "created_at" : "2000-01-23T04:56:07.000+00:00",
-  "title" : "title",
-  "view_count" : 1,
-  "famous_sentence_text" : "famous_sentence_text"
+  "evaluation_good_count" : 5,
+  "view_count" : 1
 } ]</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -1120,12 +1097,6 @@ font-style: italic;
     <div class="method-summary">自分自身のユーザーアカウント情報を更新 (<span class="nickname">updateUserByMe</span>)</div>
     <div class="method-notes"></div>
 
-    <h3 class="field-label">Path parameters</h3>
-    <div class="field-items">
-      <div class="param">user_id (required)</div>
-
-      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  default: null </div>
-    </div>  <!-- field-items -->
 
     <h3 class="field-label">Consumes</h3>
     This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
@@ -1155,12 +1126,12 @@ font-style: italic;
     <h3 class="field-label">Example data</h3>
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
-  "good_count" : 6,
   "updated_at" : "2000-01-23T04:56:07.000+00:00",
   "user_id" : 0,
   "user_name" : "user_name",
   "nick_name" : "nick_name",
   "profile_icon_image" : "profile_icon_image",
+  "evaluation_good_count" : 6,
   "created_at" : "2000-01-23T04:56:07.000+00:00"
 }</code></pre>
 
@@ -1191,8 +1162,8 @@ font-style: italic;
     <li><a href="#LoginRequest"><code>LoginRequest</code> - </a></li>
     <li><a href="#LoginResponse"><code>LoginResponse</code> - </a></li>
     <li><a href="#LogoutRequest"><code>LogoutRequest</code> - </a></li>
-    <li><a href="#Novel"><code>Novel</code> - </a></li>
-    <li><a href="#NovelOverview"><code>NovelOverview</code> - </a></li>
+    <li><a href="#NovelDetail"><code>NovelDetail</code> - </a></li>
+    <li><a href="#NovelListItem"><code>NovelListItem</code> - </a></li>
     <li><a href="#PostSentence"><code>PostSentence</code> - </a></li>
     <li><a href="#RegisterUser"><code>RegisterUser</code> - </a></li>
     <li><a href="#RegisterUserResult"><code>RegisterUserResult</code> - </a></li>
@@ -1244,7 +1215,7 @@ font-style: italic;
     </div>  <!-- field-items -->
   </div>
   <div class="model">
-    <h3><a name="Novel"><code>Novel</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <h3><a name="NovelDetail"><code>NovelDetail</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">title_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の一意のid（この値は他の小説と重複しない必要があります） format: int64</div>
@@ -1257,31 +1228,33 @@ font-style: italic;
 <div class="param">is_new (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 新着小説かどうか </div>
 <div class="param">is_famous (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 人気小説かどうか </div>
 <div class="param">view_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説の閲覧数 </div>
-<div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の作成日時 format: date-time</div>
-<div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の修正日時 format: date-time</div>
-    </div>  <!-- field-items -->
-  </div>
-  <div class="model">
-    <h3><a name="NovelOverview"><code>NovelOverview</code> - </a> <a class="up" href="#__Models">Up</a></h3>
-    <div class='model-description'></div>
-    <div class="field-items">
-      <div class="param">title_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の一意のid（この値は他の小説と重複しない必要があります） format: int64</div>
-<div class="param">title (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説のタイトル </div>
-<div class="param">famous_sentence_text (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 名言・印象に残るシーン </div>
-<div class="param">author_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の作者のid format: int64</div>
-<div class="param">author_user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のペンネーム </div>
-<div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のアイコン画像のurl </div>
-<div class="param">title_genres (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> 小説のジャンル </div>
-<div class="param">is_new (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 新着小説かどうか </div>
-<div class="param">is_famous (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 人気小説かどうか </div>
-<div class="param">view_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説の閲覧数 </div>
+<div class="param">evaluation_good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説のGood評価の数 </div>
 <div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の作成日時 format: date-time</div>
 <div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の修正日時 format: date-time</div>
 <div class="param">main_copy (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の紹介文 </div>
 <div class="param">sentence_user_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説に投稿された投稿の数 </div>
 <div class="param">sentence_hierarchy_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説に投稿された投稿の階層数 </div>
 <div class="param">reader_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説を読んだユーザーの数 </div>
-<div class="param">overview (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の概要 </div>
+<div class="param">overview (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説のあらすじ </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="NovelListItem"><code>NovelListItem</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">title_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の一意のid（この値は他の小説と重複しない必要があります） format: int64</div>
+<div class="param">title (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説のタイトル </div>
+<div class="param">famous_sentence_text (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 名言・印象に残るシーン </div>
+<div class="param">author_user_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 小説の作者のid format: int64</div>
+<div class="param">author_user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のペンネーム </div>
+<div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 小説の作者のアイコン画像のurl </div>
+<div class="param">title_genres (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">array[String]</a></span> 小説のジャンル </div>
+<div class="param">is_new (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 新着小説かどうか </div>
+<div class="param">is_famous (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> 人気小説かどうか </div>
+<div class="param">view_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説の閲覧数 </div>
+<div class="param">evaluation_good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> 小説のGood評価の数 </div>
+<div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の作成日時 format: date-time</div>
+<div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 小説の修正日時 format: date-time</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -1343,7 +1316,7 @@ font-style: italic;
 <div class="param">user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのペンネーム </div>
 <div class="param">nick_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのニックネーム </div>
 <div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーアイコン画像のurl </div>
-<div class="param">good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> Good評価の数 </div>
+<div class="param">evaluation_good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> Good評価の数 </div>
 <div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの作成日時 format: date-time</div>
 <div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの修正日時 format: date-time</div>
     </div>  <!-- field-items -->
@@ -1365,7 +1338,7 @@ font-style: italic;
 <div class="param">user_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのペンネーム </div>
 <div class="param">nick_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーのニックネーム </div>
 <div class="param">profile_icon_image (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーアイコン画像のurl </div>
-<div class="param">good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> Good評価の数 </div>
+<div class="param">evaluation_good_count (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> Good評価の数 </div>
 <div class="param">created_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの作成日時 format: date-time</div>
 <div class="param">updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> ユーザーの修正日時 format: date-time</div>
 <div class="param">birth_year_and_month (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> ユーザーの生年月（YYYY/MM） </div>


### PR DESCRIPTION
## チケット
https://techno-kuro-novel.atlassian.net/browse/CNV-133

## 修正内容
- `conovel-openapi.yml`に各種APIの定義を追加
- `openapigen/index.html`にAPIドキュメントをビルド

## 共有・相談事項
- 下記ページに`conovel-openapi.yml`のコードを貼るとSwaggerUIドキュメント形式になります
  - https://editor.swagger.io/
  - `openapigen/index.html`より見やすい形式です
  - SwaggerUIドキュメント形式は今後、backendリポジトリで正式に生成します
- 投稿テキストは後から更新できるようにすべきか？
  - 誤字脱字は修正したくなるかも
  - しかし後続投稿とストーリーが繋がらなくなるような更新は避けたい
  - 更新を許可制にすると運営側の負担が増える
  - そう考えると更新はできないようにするのがベターか？
- 更新系のメソッドはPOST / PUT / PATCH？
  - 今はPOSTにしている
  - 部分更新についてはPATCHの方が向いていそう？
  - POSTでもエンドポイントの違いで追加か更新は判別できそう
- ユーザー追加はGoogle認証のみの内容
  - その他のユーザーアカウント情報はログイン後にアカウント情報更新で行えばOK？
- 登録小説機能はイキ？毒？
  - 閲覧（ユーザー閲覧小説取得API）に統合された？
  - その場合、画面からも登録小説のUIを非表示にする？
- ゴールド、シルバー、ブロンズは毒の認識
  - 画面からもゴールド、シルバー、ブロンズのUIを非表示にする？
- ユーザーアカウント情報更新API
  - ユーザーアカウント画像も追加しています