### PR TITLE
sentencesのパラレル修正（CNV-136）& 編集中に直前の投稿が編集がされた際の検知・挙動について検討（CNV-58）

### DIFF
--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -28,6 +28,10 @@ paths:
           description: "新規投稿の追加に失敗"
         '409':
           description: "親投稿が編集されたため、投稿を保留"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ViewSentence"
   /sentences/{sentence_id}:
     get:
       tags:
@@ -266,7 +270,7 @@ components:
           $ref: "#/components/schemas/Sentence"
         parent:
           $ref: "#/components/schemas/Sentence"
-        parallel:
+        parallels:
           $ref: "#/components/schemas/Sentences"
         children:
           $ref: "#/components/schemas/Sentences"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -264,7 +264,7 @@ components:
           $ref: "#/components/schemas/Sentence"
         parent:
           $ref: "#/components/schemas/Sentence"
-        parent_parallel:
+        parallel:
           $ref: "#/components/schemas/Sentences"
         children:
           $ref: "#/components/schemas/Sentences"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -26,6 +26,8 @@ paths:
                 $ref: "#/components/schemas/ViewSentence"
         '400':
           description: "新規投稿の追加に失敗"
+        '409':
+          description: "親投稿が編集されたため、投稿を保留"
   /sentences/{sentence_id}:
     get:
       tags:
@@ -275,6 +277,10 @@ components:
           type: integer
           format: int64
           description: "親投稿のid"
+        parent_updated_at:
+          type: string
+          format: date-time
+          description: "親投稿の修正日時(投稿中の親投稿の更新有無を確認するためs)"
         sentence:
           type: string
           description: "新投稿の本文テキスト"

--- a/conovel-openapi.yml
+++ b/conovel-openapi.yml
@@ -280,7 +280,7 @@ components:
         parent_updated_at:
           type: string
           format: date-time
-          description: "親投稿の修正日時(投稿中の親投稿の更新有無を確認するためs)"
+          description: "親投稿の修正日時(投稿中の親投稿の更新有無を確認するため)"
         sentence:
           type: string
           description: "新投稿の本文テキスト"

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -483,27 +483,6 @@ font-style: italic;
     "evaluation_stay_count" : 5,
     "sentence_user_name" : "sentence_user_name"
   },
-  "parallel" : [ {
-    "sentence" : "sentence",
-    "updated_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_id" : 0,
-    "profile_icon_image" : "profile_icon_image",
-    "evaluation_good_count" : 1,
-    "created_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_user_id" : 6,
-    "evaluation_stay_count" : 5,
-    "sentence_user_name" : "sentence_user_name"
-  }, {
-    "sentence" : "sentence",
-    "updated_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_id" : 0,
-    "profile_icon_image" : "profile_icon_image",
-    "evaluation_good_count" : 1,
-    "created_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_user_id" : 6,
-    "evaluation_stay_count" : 5,
-    "sentence_user_name" : "sentence_user_name"
-  } ],
   "children" : [ {
     "sentence" : "sentence",
     "updated_at" : "2000-01-23T04:56:07.000+00:00",
@@ -535,7 +514,28 @@ font-style: italic;
     "sentence_user_id" : 6,
     "evaluation_stay_count" : 5,
     "sentence_user_name" : "sentence_user_name"
-  }
+  },
+  "parallels" : [ {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  }, {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  } ]
 }</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -601,27 +601,6 @@ font-style: italic;
     "evaluation_stay_count" : 5,
     "sentence_user_name" : "sentence_user_name"
   },
-  "parallel" : [ {
-    "sentence" : "sentence",
-    "updated_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_id" : 0,
-    "profile_icon_image" : "profile_icon_image",
-    "evaluation_good_count" : 1,
-    "created_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_user_id" : 6,
-    "evaluation_stay_count" : 5,
-    "sentence_user_name" : "sentence_user_name"
-  }, {
-    "sentence" : "sentence",
-    "updated_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_id" : 0,
-    "profile_icon_image" : "profile_icon_image",
-    "evaluation_good_count" : 1,
-    "created_at" : "2000-01-23T04:56:07.000+00:00",
-    "sentence_user_id" : 6,
-    "evaluation_stay_count" : 5,
-    "sentence_user_name" : "sentence_user_name"
-  } ],
   "children" : [ {
     "sentence" : "sentence",
     "updated_at" : "2000-01-23T04:56:07.000+00:00",
@@ -653,7 +632,96 @@ font-style: italic;
     "sentence_user_id" : 6,
     "evaluation_stay_count" : 5,
     "sentence_user_name" : "sentence_user_name"
-  }
+  },
+  "parallels" : [ {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  }, {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  } ]
+}</code></pre>
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>{
+  "parent" : {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  },
+  "children" : [ {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  }, {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  } ],
+  "main" : {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  },
+  "parallels" : [ {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  }, {
+    "sentence" : "sentence",
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_id" : 0,
+    "profile_icon_image" : "profile_icon_image",
+    "evaluation_good_count" : 1,
+    "created_at" : "2000-01-23T04:56:07.000+00:00",
+    "sentence_user_id" : 6,
+    "evaluation_stay_count" : 5,
+    "sentence_user_name" : "sentence_user_name"
+  } ]
 }</code></pre>
 
     <h3 class="field-label">Produces</h3>
@@ -672,7 +740,7 @@ font-style: italic;
         <a href="#"></a>
     <h4 class="field-label">409</h4>
     親投稿が編集されたため、投稿を保留
-        <a href="#"></a>
+        <a href="#ViewSentence">ViewSentence</a>
   </div> <!-- method -->
   <hr/>
   <h1><a name="Users">Users</a></h1>
@@ -1162,7 +1230,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">main (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">Sentence</a></span>  </div>
 <div class="param">parent (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">Sentence</a></span>  </div>
-<div class="param">parallel (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">array[Sentence]</a></span>  </div>
+<div class="param">parallels (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">array[Sentence]</a></span>  </div>
 <div class="param">children (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">array[Sentence]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>

--- a/openapigen/index.html
+++ b/openapigen/index.html
@@ -483,7 +483,7 @@ font-style: italic;
     "evaluation_stay_count" : 5,
     "sentence_user_name" : "sentence_user_name"
   },
-  "children" : [ {
+  "parallel" : [ {
     "sentence" : "sentence",
     "updated_at" : "2000-01-23T04:56:07.000+00:00",
     "sentence_id" : 0,
@@ -504,7 +504,7 @@ font-style: italic;
     "evaluation_stay_count" : 5,
     "sentence_user_name" : "sentence_user_name"
   } ],
-  "parent_parallel" : [ {
+  "children" : [ {
     "sentence" : "sentence",
     "updated_at" : "2000-01-23T04:56:07.000+00:00",
     "sentence_id" : 0,
@@ -601,7 +601,7 @@ font-style: italic;
     "evaluation_stay_count" : 5,
     "sentence_user_name" : "sentence_user_name"
   },
-  "children" : [ {
+  "parallel" : [ {
     "sentence" : "sentence",
     "updated_at" : "2000-01-23T04:56:07.000+00:00",
     "sentence_id" : 0,
@@ -622,7 +622,7 @@ font-style: italic;
     "evaluation_stay_count" : 5,
     "sentence_user_name" : "sentence_user_name"
   } ],
-  "parent_parallel" : [ {
+  "children" : [ {
     "sentence" : "sentence",
     "updated_at" : "2000-01-23T04:56:07.000+00:00",
     "sentence_id" : 0,
@@ -669,6 +669,9 @@ font-style: italic;
         <a href="#ViewSentence">ViewSentence</a>
     <h4 class="field-label">400</h4>
     新規投稿の追加に失敗
+        <a href="#"></a>
+    <h4 class="field-label">409</h4>
+    親投稿が編集されたため、投稿を保留
         <a href="#"></a>
   </div> <!-- method -->
   <hr/>
@@ -1087,6 +1090,7 @@ font-style: italic;
     <div class='model-description'></div>
     <div class="field-items">
       <div class="param">parent_sentence_id (optional)</div><div class="param-desc"><span class="param-type"><a href="#long">Long</a></span> 親投稿のid format: int64</div>
+<div class="param">parent_updated_at (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> 親投稿の修正日時(投稿中の親投稿の更新有無を確認するため) format: date-time</div>
 <div class="param">sentence (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> 新投稿の本文テキスト </div>
     </div>  <!-- field-items -->
   </div>
@@ -1158,7 +1162,7 @@ font-style: italic;
     <div class="field-items">
       <div class="param">main (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">Sentence</a></span>  </div>
 <div class="param">parent (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">Sentence</a></span>  </div>
-<div class="param">parent_parallel (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">array[Sentence]</a></span>  </div>
+<div class="param">parallel (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">array[Sentence]</a></span>  </div>
 <div class="param">children (optional)</div><div class="param-desc"><span class="param-type"><a href="#Sentence">array[Sentence]</a></span>  </div>
     </div>  <!-- field-items -->
   </div>


### PR DESCRIPTION
## チケット

- sentencesのパラレル修正
  - https://techno-kuro-novel.atlassian.net/browse/CNV-136
 
 - 編集中に直前の投稿が編集がされた際の検知・挙動について検討
   - https://techno-kuro-novel.atlassian.net/browse/CNV-58

## 修正内容

- sentencesのパラレル修正
  - 投稿閲覧画面の上部にあった親のパラレル投稿は表示しない（親投稿のみ表示）
  - 画面中央のmain投稿のパラレル投稿も読めるように左右に「前へ」「次へ」アイコンを追加する（子投稿の左右と同様）
 
 - 編集中に直前の投稿が編集がされた際の検知・挙動について検討
   - 投稿画面を開いた時に`Sentences`を呼び出す
   - POSTするときに`Parent`の`updated_at`をリクエストに含めて送る
   - バックエンドでは、`Parent`の`updated_at`が不一致であればエラーを返す（4XX）
     - 一致していたら登録する
     - エラーの中に新しい現在の`Sentences`も一緒に返す
   - フロントでは、エラーが返ってきたら、Parentの編集が行われたことがわかるようトースト等出す、エラーに入っている新しい現在のSentencesが入っているのでそれで画面上でのParentの文章切り替え
   
## 共有・検討事項

- sentencesのパラレル修正
  - 一番シンプルな修正案（現状はこの形）
    - パラメータ名を`parent_parallel`→`parallel`に変更（データは複数件の配列）
  - 別の修正案：
    - バック側でmainのパラレル投稿の中から一つ前、一つ後の投稿idを取得して、それの二つのidをレスポンスで返す？
    - 参考：https://github.com/Conovel/frontend/pull/20#issuecomment-2480312805

- 編集中に直前の投稿が編集がされた際の検知・挙動について検討
  - 親投稿に編集があった場合のステータスコード、`409`にしてみました
    - 参考1：https://developer.mozilla.org/ja/docs/Web/HTTP/Status#クライアントエラーレスポンス
    - 参考2：https://developer.mozilla.org/ja/docs/Web/HTTP/Status/409
