### PR TITLE
[フロント&バック] .envファイルの配置位置変更と動作確認(CNV-197)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - PORT=3000
     env_file:
-      - .env
+      - ./frontend/.env
     networks:
       - conovel-network
     volumes:
@@ -27,39 +27,34 @@ services:
     networks:
       - conovel-network
     depends_on:
-      - db
-    environment:
-      - DB_HOST=${DB_HOST}
-      - DB_USERNAME=${DB_USERNAME}
-      - DB_PASSWORD=${DB_PASSWORD}
-      - DEVELOPMENT_ORIGIN_URL=${DEVELOPMENT_ORIGIN_URL}
-      - PRODUCTION_ORIGIN_URL=${PRODUCTION_ORIGIN_URL}
+      db:
+        condition: service_healthy
     env_file:
-      - .env
+      - ./backend/.env
     volumes:
       - ./backend:/app
       - swagger_data:/app/swagger
-    command: sh -c "bundle exec rails db:migrate db:seed && bundle exec puma -C config/puma.rb"
+    command: sh -c "bundle exec rails db:create db:migrate db:seed && bundle exec puma -C config/puma.rb"
 
   db:
     container_name: db
     build:
       context: .
       dockerfile: builder/db/Dockerfile
-    environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: myapp_development
-      MYSQL_USER: ${MYAPP_DATABASE_USERNAME}
-      MYSQL_PASSWORD: ${MYAPP_DATABASE_PASSWORD}
     ports:
       - "3306:3306"
     networks:
       - conovel-network
     env_file:
-      - .env
+      - ./backend/.env
     volumes:
       - db_data:/var/lib/mysql
       - ./my.cnf:/etc/mysql/conf.d/my.cnf
+    healthcheck:
+      test: ["CMD", "mysql", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}", "-e", "SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
 networks:
   conovel-network:


### PR DESCRIPTION
## JIRAチケットURL

https://techno-kuro-novel.atlassian.net/browse/CNV-197

---
## 実装内容

- ルート直下の.envファイルをfrontend/.envに移動
  - フロントエンドに関係する環境変数（VITE_〜）以外は除外
- ルート直下の.envファイルをbackend/.envに移動
  - フロントエンドに関係する環境変数（VITE_〜）は除外している
- ルート直下の.envファイルにDBのMYSQL_ROOT_PASSWORDのみ残す
  - ここに設定しないとdockerのMySQLが起動エラーになったため

## 自身で確認した動作のエビデンス（スクショ等）

フロント：
localhost:3000で画面が表示される
<img width="341" alt="スクリーンショット 2025-04-21 13 27 10" src="https://github.com/user-attachments/assets/9147889c-7ef1-421f-8971-260b743d4996" />

他の画面にも遷移できる
<img width="338" alt="スクリーンショット 2025-04-21 18 56 17" src="https://github.com/user-attachments/assets/c61ddf55-af5c-4d28-beb5-03083f5de680" />

バック：
localhost:3001のAPIをPostmanで叩き、レスポンスを取得できる
<img width="847" alt="スクリーンショット 2025-04-21 18 57 08" src="https://github.com/user-attachments/assets/ec4567c0-b1ea-4b77-ba57-42faed8a6e97" />
