### PR TITLE
Windowsで db コンテナが起動しない現象の是正

### DIFF
--- a/builder/db/Dockerfile
+++ b/builder/db/Dockerfile
@@ -1,1 +1,3 @@
 FROM mysql:8.4.2-oraclelinux9
+COPY my.cnf /etc/mysql/conf.d/my.cnf
+RUN chmod 644 /etc/mysql/conf.d/my.cnf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,6 @@ services:
       - ./backend/.env
     volumes:
       - db_data:/var/lib/mysql
-      - ./my.cnf:/etc/mysql/conf.d/my.cnf
     healthcheck:
       test: ["CMD", "mysql", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}", "-e", "SELECT 1"]
       interval: 10s


### PR DESCRIPTION
Windowsでは、明確な ファイルやパスごとのパーミッションは、Windowsの機能で設定可能ですが、Dockerとは異なる機能です。
mac であれば、Docker と同等の機能でパーミッションが設定され、Docker は mac のパーミッションを引き継いで動作しますが、Windowsだとその動作はなく、基本的にDockerからは、すべての権限が許可された状態と判断して動作します。

今回DBコンテナが動作しなかった原因は上記で、起動時には以下の現象が発生していました。

https://chatgpt.com/share/68823be0-9420-8007-bd8d-50d48c504e24

これに対応する修正です。

なお、上記のログ
mysqld: [Warning] World-writable config file '/etc/mysql/conf.d/my.cnf' is ignored.
は、DockerDesktopから容易に確認が可能です。

「起動しなかった」は表現があいまいであり、何が起きていたかを克明に表現することが必要で、まずはこのPRの取り込みよりも先に、上記の現象を捕捉することができるかを確認してください。